### PR TITLE
 Add support nested NameID in attribute value

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -814,10 +814,10 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
       var attrValueMapper = function(value) {
         if(typeof value === 'string') {
           return value;
-        } else if (value._) {
-          return value._;
         } else if (value.NameID && value.NameID[0]) {
           return value.NameID[0]._;
+        } else {
+          return value._;
         }
       };
 

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -812,7 +812,13 @@ SAML.prototype.processValidlySignedAssertion = function(xml, inResponseTo, callb
       }));
 
       var attrValueMapper = function(value) {
-        return typeof value === 'string' ? value : value._;
+        if(typeof value === 'string') {
+          return value;
+        } else if (value._) {
+          return value._;
+        } else if (value.NameID && value.NameID[0]) {
+          return value.NameID[0]._;
+        }
       };
 
       if (attributes) {


### PR DESCRIPTION
Addressing #245.

This is a common format in IdPs in the UK Federation, including the test IdP (https://www.ukfederation.org.uk/content/Documents/TestIdP), which provide values like the following:

```
<saml2:Attribute
           FriendlyName="eduPersonTargetedID"
           Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10"
           NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
          <saml2:AttributeValue>
                <saml2:NameID
                   Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
                   NameQualifier="https://test-idp.ukfederation.org.uk/idp/shibboleth"
                   SPNameQualifier="https://test.ukfederation.org.uk/entity">
                  xY1234567890ACdFGGhjmkklljA=
                </saml2:NameID>
          </saml2:AttributeValue>
</saml2:Attribute>
```