### PR TITLE
Multiple callback urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ passport.use(new SamlStrategy(
 #### Config parameter details:
 
  * **Core**
-  * `callbackUrl`: full callbackUrl (overrides path/protocol if supplied)
+  * `callbackUrl`: full callbackUrl (overrides path/protocol if supplied); multiple can be supplied as either an array of strings, or an array of objects `{ callbackUrl: 'string', default: true, metadataDefault: true }`. If the default can't be determined the first one will be used. 
   * `path`: path to callback; will be combined with protocol and server host information to construct callback url if `callbackUrl` is not specified (default: `/saml/consume`)
   * `protocol`: protocol for callback; will be combined with path and server host information to construct callback url if `callbackUrl` is not specified (default: `http://`)
   * `host`: host for callback; will be combined with path and protocol to construct callback url if `callbackUrl` is not specified (default: `localhost`)

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -93,7 +93,7 @@ SAML.prototype.getCallbackUrl = function (req) {
   if (this.options.callbackUrl && this.options.callbackUrl.constructor === Array) {
     // Multiple callback urls have been defined use the default one, or if not found - The first one.
     if(this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default; }).length === 1) {
-      return this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default; }).callbackUrl;
+      return this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default; })[0].callbackUrl;
     } else if (this.options.callbackUrl.length > 0 ){
       return (this.options.callbackUrl[0].callbackUrl) ? this.options.callbackUrl[0].callbackUrl : this.options.callbackUrl[0];
     } else {

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -86,14 +86,14 @@ SAML.prototype.getDefaultCallbackUrl = function (req) {
       host = this.options.host;
     }
     return this.getProtocol(req) + host + this.options.path;
-;}
+};
 
 SAML.prototype.getCallbackUrl = function (req) {
     // Post-auth destination
   if (this.options.callbackUrl && this.options.callbackUrl.constructor === Array) {
     // Multiple callback urls have been defined use the default one, or if not found - The first one.
-    if(this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default }).length === 1) {
-      return this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default }).callbackUrl;
+    if(this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default; }).length === 1) {
+      return this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default; }).callbackUrl;
     } else if (this.options.callbackUrl.length > 0 ){
       return (this.options.callbackUrl[0].callbackUrl) ? this.options.callbackUrl[0].callbackUrl : this.options.callbackUrl[0];
     } else {

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -86,14 +86,14 @@ SAML.prototype.getDefaultCallbackUrl = function (req) {
       host = this.options.host;
     }
     return this.getProtocol(req) + host + this.options.path;
-}
+;}
 
 SAML.prototype.getCallbackUrl = function (req) {
     // Post-auth destination
   if (this.options.callbackUrl && this.options.callbackUrl.constructor === Array) {
     // Multiple callback urls have been defined use the default one, or if not found - The first one.
-    if(this.options.callbackUrl.filter(urlOptions => urlOptions.default).length === 1) {
-      return this.options.callbackUrl.filter(urlOptions => urlOptions.default).callbackUrl;
+    if(this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default }).length === 1) {
+      return this.options.callbackUrl.filter(function (urlOptions) { return urlOptions.default }).callbackUrl;
     } else if (this.options.callbackUrl.length > 0 ){
       return (this.options.callbackUrl[0].callbackUrl) ? this.options.callbackUrl[0].callbackUrl : this.options.callbackUrl[0];
     } else {
@@ -109,7 +109,7 @@ SAML.prototype.getCallbackUrl = function (req) {
 SAML.prototype.getCallbackUrls = function (req) {
   if (this.options.callbackUrl && this.options.callbackUrl.constructor === Array && this.options.callbackUrl.length > 0) { 
     var setFirstCallbackAsDefault = false; 
-    var callbackUrls = this.options.callbackUrl.map((callbackUrlOptions) => {
+    var callbackUrls = this.options.callbackUrl.map(function (callbackUrlOptions) {
       if (typeof callbackUrlOptions === 'string' ) {
         setFirstCallbackAsDefault = true;
         return {
@@ -137,7 +137,7 @@ SAML.prototype.getCallbackUrls = function (req) {
       default: true
     }];
   }
-}
+};
 
 SAML.prototype.generateUniqueID = function () {
   return crypto.randomBytes(10).toString('hex');
@@ -1058,13 +1058,13 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
   }
 
   metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
-   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = this.getCallbackUrls({}).map((callbackUrlOptions, index) => {
+   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = this.getCallbackUrls({}).map(function(callbackUrlOptions, index) {
       return {
         '@index': index,
         '@isDefault': callbackUrlOptions.default,
         '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
         '@Location': callbackUrlOptions.callbackUrl
-      }
+      };
   });
 
   return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -78,20 +78,66 @@ SAML.prototype.getProtocol = function (req) {
   return this.options.protocol || (req.protocol || 'http').concat('://');
 };
 
-SAML.prototype.getCallbackUrl = function (req) {
-    // Post-auth destination
-  if (this.options.callbackUrl) {
-    return this.options.callbackUrl;
-  } else {
-    var host;
+SAML.prototype.getDefaultCallbackUrl = function (req) {
+  var host;
     if (req.headers) {
       host = req.headers.host;
     } else {
       host = this.options.host;
     }
     return this.getProtocol(req) + host + this.options.path;
+}
+
+SAML.prototype.getCallbackUrl = function (req) {
+    // Post-auth destination
+  if (this.options.callbackUrl && this.options.callbackUrl.constructor === Array) {
+    // Multiple callback urls have been defined use the default one, or if not found - The first one.
+    if(this.options.callbackUrl.filter(urlOptions => urlOptions.default).length === 1) {
+      return this.options.callbackUrl.filter(urlOptions => urlOptions.default).callbackUrl;
+    } else if (this.options.callbackUrl.length > 0 ){
+      return (this.options.callbackUrl[0].callbackUrl) ? this.options.callbackUrl[0].callbackUrl : this.options.callbackUrl[0];
+    } else {
+      return this.getDefaultCallbackUrl(req);
+    }
+  } else if(this.options.callbackUrl){
+    return this.options.callbackUrl;
+  } else {
+    return this.getDefaultCallbackUrl(req);
   }
 };
+
+SAML.prototype.getCallbackUrls = function (req) {
+  if (this.options.callbackUrl && this.options.callbackUrl.constructor === Array && this.options.callbackUrl.length > 0) { 
+    var setFirstCallbackAsDefault = false; 
+    var callbackUrls = this.options.callbackUrl.map((callbackUrlOptions) => {
+      if (typeof callbackUrlOptions === 'string' ) {
+        setFirstCallbackAsDefault = true;
+        return {
+          callbackUrl: callbackUrlOptions,
+          default: false
+        };
+      } else {
+        return {
+          callbackUrl: callbackUrlOptions.callbackUrl,
+          default: callbackUrlOptions.default
+        };
+      }
+    });
+    if (setFirstCallbackAsDefault) callbackUrls[0].default = true;
+    return callbackUrls;
+  } else if (this.options.callbackUrl) 
+  {
+    return [{
+      callbackUrl: this.getCallbackUrl(req),
+      default: true
+    }];
+  } else {
+    return [{
+      callbackUrl: this.getDefaultCallbackUrl(req),
+      default: true
+    }];
+  }
+}
 
 SAML.prototype.generateUniqueID = function () {
   return crypto.randomBytes(10).toString('hex');
@@ -1012,12 +1058,14 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
   }
 
   metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
-  metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
-    '@index': '1',
-    '@isDefault': 'true',
-    '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-    '@Location': this.getCallbackUrl({})
-  };
+   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = this.getCallbackUrls({}).map((callbackUrlOptions, index) => {
+      return {
+        '@index': index,
+        '@isDefault': callbackUrlOptions.default,
+        '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+        '@Location': callbackUrlOptions.callbackUrl
+      }
+  });
 
   return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
 };

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -114,27 +114,34 @@ SAML.prototype.getCallbackUrls = function (req) {
         setFirstCallbackAsDefault = true;
         return {
           callbackUrl: callbackUrlOptions,
-          default: false
+          default: false,
+          metadataDefault: false
         };
       } else {
         return {
           callbackUrl: callbackUrlOptions.callbackUrl,
-          default: callbackUrlOptions.default
+          default: callbackUrlOptions.default,
+          metadataDefault: callbackUrlOptions.metadataDefault
         };
       }
     });
-    if (setFirstCallbackAsDefault) callbackUrls[0].default = true;
+    if (setFirstCallbackAsDefault) {
+      callbackUrls[0].default = true;
+      callbackUrls[0].metadataDefault = true;    
+    }
     return callbackUrls;
   } else if (this.options.callbackUrl) 
   {
     return [{
       callbackUrl: this.getCallbackUrl(req),
-      default: true
+      default: true,
+      metadataDefault: true
     }];
   } else {
     return [{
       callbackUrl: this.getDefaultCallbackUrl(req),
-      default: true
+      default: true,
+      metadataDefault: true
     }];
   }
 };
@@ -1061,7 +1068,7 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
    metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = this.getCallbackUrls({}).map(function(callbackUrlOptions, index) {
       return {
         '@index': index,
-        '@isDefault': callbackUrlOptions.default,
+        '@isDefault': callbackUrlOptions.metadataDefault,
         '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
         '@Location': callbackUrlOptions.callbackUrl
       };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "passport-saml",
   "version": "0.32.1",
-  "license" : "MIT",
+  "license": "MIT",
   "keywords": [
     "saml",
     "adfs",

--- a/test/static/expected metadata without key multiple callbacks.xml
+++ b/test/static/expected metadata without key multiple callbacks.xml
@@ -3,5 +3,6 @@
   <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <AssertionConsumerService index="0" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+    <AssertionConsumerService index="1" isDefault="false" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback2"/>
   </SPSSODescriptor>
 </EntityDescriptor>

--- a/test/static/expected metadata.xml
+++ b/test/static/expected metadata.xml
@@ -38,6 +38,6 @@ nwtlCg==
       <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
     </KeyDescriptor>
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
-    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+    <AssertionConsumerService index="0" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
   </SPSSODescriptor>
 </EntityDescriptor>

--- a/test/tests.js
+++ b/test/tests.js
@@ -692,10 +692,12 @@ describe( 'passport-saml /', function() {
           issuer: 'http://example.serviceprovider.com',
           callbackUrl: [{
             default: true, 
-            callbackUrl:'http://example.serviceprovider.com/saml/callback'
+            callbackUrl:'http://example.serviceprovider.com/saml/callback',
+            metadataDefault: true
           },
           { default: false,
-            callbackUrl: 'http://example.serviceprovider.com/saml/callback2'
+            callbackUrl: 'http://example.serviceprovider.com/saml/callback2',
+            metadataDefault: false
           }],
           identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
         };

--- a/test/tests.js
+++ b/test/tests.js
@@ -675,6 +675,37 @@ describe( 'passport-saml /', function() {
         done();
       });
 
+      it( 'config with callbackUrl as array of string should pass', function( done ) {
+        var samlConfig = {
+          issuer: 'http://example.serviceprovider.com',
+          callbackUrl: ['http://example.serviceprovider.com/saml/callback', 'http://example.serviceprovider.com/saml/callback2'],
+          identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+        };
+        var expectedMetadata = fs.readFileSync(__dirname + '/static/expected metadata without key multiple callbacks.xml', 'utf-8');
+
+        testMetadata( samlConfig, expectedMetadata );
+        done();
+      });
+
+      it( 'config with callbackUrl as array of objects should pass', function( done ) {
+        var samlConfig = {
+          issuer: 'http://example.serviceprovider.com',
+          callbackUrl: [{
+            default: true, 
+            callbackUrl:'http://example.serviceprovider.com/saml/callback'
+          },
+          { default: false,
+            callbackUrl: 'http://example.serviceprovider.com/saml/callback2'
+          }],
+          identifierFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
+        };
+        var expectedMetadata = fs.readFileSync(__dirname + '/static/expected metadata without key multiple callbacks.xml', 'utf-8');
+
+        testMetadata( samlConfig, expectedMetadata );
+        done();
+      });
+
+
       it( 'config with protocol, path, host, and decryptionPvk should pass', function( done ) {
         var samlConfig = {
           issuer: 'http://example.serviceprovider.com',


### PR DESCRIPTION
Multiple callback urls can be now be defined and will be generated within the metadata.xml
Only the default callback is used when sending AuthnRequests. If no default is set, the first option is used as the default.

Can either be set as an array of objects or an array of strings. Existing implementations can still just assign a singular string.