### PR TITLE
Fix for issue #252 RequestedAuthnContext: Comparison type.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
 node_modules/
 .tern-port
+
+# =========================
+# Package manger lock file
+# =========================
+
+package-lock.json
+yarn.lock
+
+# =========================
+# Webstorm
+# =========================
+
+.idea

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ passport.use(new SamlStrategy(
   * `acceptedClockSkewMs`: Time in milliseconds of skew that is acceptable between client and server when checking `OnBefore` and `NotOnOrAfter` assertion condition validity timestamps.  Setting to `-1` will disable checking these conditions entirely.  Default is `0`.
   * `attributeConsumingServiceIndex`: optional `AttributeConsumingServiceIndex` attribute to add to AuthnRequest to instruct the IDP which attribute set to attach to the response ([link](http://blog.aniljohn.com/2014/01/data-minimization-front-channel-saml-attribute-requests.html))
   * `disableRequestedAuthnContext`: if truthy, do not request a specific authentication context. This is [known to help when authenticating against Active Directory](https://github.com/bergie/passport-saml/issues/226) (AD FS) servers.
+  * `comparisonMethod`: optional comparison method used to evaluate the requested context classes or statements, one of 'exact' (default), 'minimum', 'maximum', or 'better'.
   * `authnContext`: if truthy, name identifier format to request auth context (default: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`)
   * `forceAuthn`: if set to true, the initial SAML request from the service provider specifies that the IdP should force re-authentication of the user, even if they possess a valid session.
   * `providerName`: optional human-readable name of the requester for use by the presenter's user agent or the identity provider

--- a/lib/passport-saml/config/schema.js
+++ b/lib/passport-saml/config/schema.js
@@ -1,4 +1,4 @@
-const SCHEME = {
+var SCHEME = {
   comparison: {
     values: ['exact', 'minimum', 'maximum', 'better'],
     default: 'exact'

--- a/lib/passport-saml/config/schema.js
+++ b/lib/passport-saml/config/schema.js
@@ -1,0 +1,8 @@
+const SCHEME = {
+  comparison: {
+    values: ['exact', 'minimum', 'maximum', 'better'],
+    default: 'exact'
+  }
+};
+
+module.exports = SCHEME;

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -11,7 +11,6 @@ var xpath = xmlCrypto.xpath;
 var Q = require('q');
 
 var InMemoryCacheProvider = require('./inmemory-cache-provider.js').CacheProvider;
-
 var SCHEMA = require('./config/schema');
 
 var SAML = function (options) {

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -8,8 +8,11 @@ var querystring = require('querystring');
 var xmlbuilder = require('xmlbuilder');
 var xmlenc = require('xml-encryption');
 var xpath = xmlCrypto.xpath;
-var InMemoryCacheProvider = require('./inmemory-cache-provider.js').CacheProvider;
 var Q = require('q');
+
+var InMemoryCacheProvider = require('./inmemory-cache-provider.js').CacheProvider;
+
+var SCHEMA = require('./config/schema');
 
 var SAML = function (options) {
   var self = this;
@@ -182,7 +185,8 @@ SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
     if (!self.options.disableRequestedAuthnContext) {
       request['samlp:AuthnRequest']['samlp:RequestedAuthnContext'] = {
         '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-        '@Comparison': 'exact',
+        '@Comparison': SCHEMA.comparison.values.indexOf(self.options.comparisonMethod) !== -1 ?
+          self.options.comparisonMethod : SCHEMA.comparison.default,
         'saml:AuthnContextClassRef': {
           '@xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion',
           '#text': self.options.authnContext

--- a/test/tests.js
+++ b/test/tests.js
@@ -294,6 +294,146 @@ describe( 'passport-saml /', function() {
                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
                        '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
       },
+      { name: "Config #2 Comparison:exact",
+        config: {
+          issuer: 'http://exampleSp.com/saml',
+          identifierFormat: 'alternateIdentifier',
+          passive: true,
+          attributeConsumingServiceIndex: 123,
+          forceAuthn: false,
+          comparisonMethod: 'exact'
+        },
+        result: {
+          'samlp:AuthnRequest':
+            { '$':
+                { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                  Version: '2.0',
+                  ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                  AssertionConsumerServiceURL: 'http://localhost:3033/login',
+                  AttributeConsumingServiceIndex: '123',
+                  Destination: 'https://wwwexampleIdp.com/saml',
+                  IsPassive: 'true'},
+              'saml:Issuer':
+                [ { _: 'http://exampleSp.com/saml',
+                  '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+              'samlp:NameIDPolicy':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Format: 'alternateIdentifier',
+                      AllowCreate: 'true' } } ],
+              'samlp:RequestedAuthnContext':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Comparison: 'exact' },
+                  'saml:AuthnContextClassRef':
+                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+                      '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
+      },
+      { name: "Config #2 Comparison:minimum",
+        config: {
+          issuer: 'http://exampleSp.com/saml',
+          identifierFormat: 'alternateIdentifier',
+          passive: true,
+          attributeConsumingServiceIndex: 123,
+          forceAuthn: false,
+          comparisonMethod: 'minimum'
+        },
+        result: {
+          'samlp:AuthnRequest':
+            { '$':
+                { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                  Version: '2.0',
+                  ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                  AssertionConsumerServiceURL: 'http://localhost:3033/login',
+                  AttributeConsumingServiceIndex: '123',
+                  Destination: 'https://wwwexampleIdp.com/saml',
+                  IsPassive: 'true'},
+              'saml:Issuer':
+                [ { _: 'http://exampleSp.com/saml',
+                  '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+              'samlp:NameIDPolicy':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Format: 'alternateIdentifier',
+                      AllowCreate: 'true' } } ],
+              'samlp:RequestedAuthnContext':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Comparison: 'minimum' },
+                  'saml:AuthnContextClassRef':
+                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+                      '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
+      },
+      { name: "Config #2 Comparison:maximum",
+        config: {
+          issuer: 'http://exampleSp.com/saml',
+          identifierFormat: 'alternateIdentifier',
+          passive: true,
+          attributeConsumingServiceIndex: 123,
+          forceAuthn: false,
+          comparisonMethod: 'maximum'
+        },
+        result: {
+          'samlp:AuthnRequest':
+            { '$':
+                { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                  Version: '2.0',
+                  ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                  AssertionConsumerServiceURL: 'http://localhost:3033/login',
+                  AttributeConsumingServiceIndex: '123',
+                  Destination: 'https://wwwexampleIdp.com/saml',
+                  IsPassive: 'true'},
+              'saml:Issuer':
+                [ { _: 'http://exampleSp.com/saml',
+                  '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+              'samlp:NameIDPolicy':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Format: 'alternateIdentifier',
+                      AllowCreate: 'true' } } ],
+              'samlp:RequestedAuthnContext':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Comparison: 'maximum' },
+                  'saml:AuthnContextClassRef':
+                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+                      '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
+      },
+      { name: "Config #2 Comparison:better",
+        config: {
+          issuer: 'http://exampleSp.com/saml',
+          identifierFormat: 'alternateIdentifier',
+          passive: true,
+          attributeConsumingServiceIndex: 123,
+          forceAuthn: false,
+          comparisonMethod: 'better'
+        },
+        result: {
+          'samlp:AuthnRequest':
+            { '$':
+                { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                  Version: '2.0',
+                  ProtocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+                  AssertionConsumerServiceURL: 'http://localhost:3033/login',
+                  AttributeConsumingServiceIndex: '123',
+                  Destination: 'https://wwwexampleIdp.com/saml',
+                  IsPassive: 'true'},
+              'saml:Issuer':
+                [ { _: 'http://exampleSp.com/saml',
+                  '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ],
+              'samlp:NameIDPolicy':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Format: 'alternateIdentifier',
+                      AllowCreate: 'true' } } ],
+              'samlp:RequestedAuthnContext':
+                [ { '$':
+                    { 'xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
+                      Comparison: 'better' },
+                  'saml:AuthnContextClassRef':
+                    [ { _: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
+                      '$': { 'xmlns:saml': 'urn:oasis:names:tc:SAML:2.0:assertion' } } ] } ] } }
+      },
       { name: "Uncompressed config #2",
         config: {
           issuer: 'http://exampleSp.com/saml',


### PR DESCRIPTION
Fix for issue [#252 RequestedAuthnContext: Comparison type](https://github.com/node-saml/passport-saml/issue/252).

The "comparisonMethod" is added as a new parameter for config. Details:

 - Bug fix
 - Doc update
 - Tested