### PR TITLE
Add metadata namespace prefix "md:" when generating metadata.xml

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -976,7 +976,7 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
   var SP = {'md:SPSSODescriptor' : {
     '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
   }};
-  doc.ele(SP);
+  var spss = doc.ele(SP);
 
   if (this.options.decryptionPvk) {
     if (!decryptionCert) {
@@ -1004,7 +1004,7 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
       ]
     }};
-    doc.ele(K);
+    spss.ele(K);
   }
 
   if (this.options.logoutCallbackUrl) {
@@ -1012,11 +1012,11 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
       '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
       '@Location': this.options.logoutCallbackUrl
     }};
-    doc.ele(L);
+      spss.ele(L);
   }
 
   var N = { 'md:NameIDFormat' : this.options.identifierFormat};
-  doc.ele(N);
+    spss.ele(N);
 
   var S = { 'md:AssertionConsumerService' : {
     '@index': '1',
@@ -1024,7 +1024,7 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
     '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
     '@Location': this.getCallbackUrl({})
   }};
-  doc.ele(S);
+  spss.ele(S);
 
 
   var ret = doc.end({ pretty: true, indent: '  ', newline: '\n' });

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -965,17 +965,18 @@ function processValidlySignedPostRequest(self, doc, callback) {
 }
 
 SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
-  var metadata = {
-    'EntityDescriptor' : {
-      '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
-      '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
-      '@entityID': this.options.issuer,
-      '@ID': this.options.issuer.replace(/\W/g, '_'),
-      'SPSSODescriptor' : {
-        '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
-      },
-    }
-  };
+
+  var root = {'md:EntityDescriptor' : {
+    '@xmlns:md': 'urn:oasis:names:tc:SAML:2.0:metadata',
+    '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
+    '@entityID': this.options.issuer,
+    '@ID': this.options.issuer.replace(/\W/g, '_'),
+  }};
+  var doc = xmlbuilder.create(root);
+  var SP = {'md:SPSSODescriptor' : {
+    '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
+  }};
+  doc.ele(SP);
 
   if (this.options.decryptionPvk) {
     if (!decryptionCert) {
@@ -987,7 +988,8 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
     decryptionCert = decryptionCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );
     decryptionCert = decryptionCert.replace( /\r\n/g, '\n' );
 
-    metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = {
+
+    var K = { 'md:KeyDescriptor' : {
       'ds:KeyInfo' : {
         'ds:X509Data' : {
           'ds:X509Certificate': {
@@ -995,31 +997,38 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert ) {
           }
         }
       },
-      'EncryptionMethod' : [
+      'md:EncryptionMethod' : [
         // this should be the set that the xmlenc library supports
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes256-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
       ]
-    };
+    }};
+    doc.ele(K);
   }
 
   if (this.options.logoutCallbackUrl) {
-    metadata.EntityDescriptor.SPSSODescriptor.SingleLogoutService = {
+    var L = {'md:SingleLogoutService' : {
       '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
       '@Location': this.options.logoutCallbackUrl
-    };
+    }};
+    doc.ele(L);
   }
 
-  metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = this.options.identifierFormat;
-  metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
+  var N = { 'md:NameIDFormat' : this.options.identifierFormat};
+  doc.ele(N);
+
+  var S = { 'md:AssertionConsumerService' : {
     '@index': '1',
     '@isDefault': 'true',
     '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
     '@Location': this.getCallbackUrl({})
-  };
+  }};
+  doc.ele(S);
 
-  return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
+
+  var ret = doc.end({ pretty: true, indent: '  ', newline: '\n' });
+  return ret;
 };
 
 exports.SAML = SAML;

--- a/test/static/expected metadata without key.xml
+++ b/test/static/expected metadata without key.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
-  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
-    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
-  </SPSSODescriptor>
-</EntityDescriptor>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+    <md:AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>

--- a/test/static/expected metadata.xml
+++ b/test/static/expected metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
-  <SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
-    <KeyDescriptor>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="http://example.serviceprovider.com" ID="http___example_serviceprovider_com">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:KeyDescriptor>
       <ds:KeyInfo>
         <ds:X509Data>
           <ds:X509Certificate>MIIEsDCCApigAwIBAgIBADANBgkqhkiG9w0BAQUFADATMREwDwYDVQQDEwgxMC4w
@@ -33,11 +33,11 @@ nwtlCg==
 </ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
-      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
-    </KeyDescriptor>
-    <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
-    <AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
-  </SPSSODescriptor>
-</EntityDescriptor>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+    </md:KeyDescriptor>
+    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+    <md:AssertionConsumerService index="1" isDefault="true" Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://example.serviceprovider.com/saml/callback"/>
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>


### PR DESCRIPTION
Apolgize for my earlier mistake.  I think this code has the proper position of the metadata elements.  This again is to help my automation process for configure trust with our IDP service.  This would place the namespace of the metadata prefix in the front of the metadata generated xml.