### PR TITLE
Private Certificate should be called Private Key

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -151,7 +151,7 @@ SAML.prototype.signRequest = function (samlMessage) {
     samlMessageToSign.SigAlg = samlMessage.SigAlg;
   }
   signer.update(querystring.stringify(samlMessageToSign));
-  samlMessage.Signature = signer.sign(this.options.privateCert, 'base64');
+  samlMessage.Signature = signer.sign(this.options.privateCert || this.options.privateKey, 'base64');
 };
 
 SAML.prototype.generateAuthorizeRequest = function (req, isPassive, callback) {
@@ -336,8 +336,8 @@ SAML.prototype.requestToUrl = function (request, response, operation, additional
     Object.keys(additionalParameters).forEach(function(k) {
       samlMessage[k] = additionalParameters[k];
     });
-
-    if (self.options.privateCert) {
+    var privateKey = self.options.privateCert || self.options.privateKey;
+    if (privateKey) {
       try {
         if (!self.options.entryPoint) {
           throw new Error('"entryPoint" config parameter is required for signed messages');
@@ -1189,17 +1189,17 @@ SAML.prototype.generateServiceProviderMetadata = function( decryptionCert, signi
         "Missing decryptionCert while generating metadata for decrypting service provider");
     }
   }
-
-  if(this.options.privateCert){
+  var privateKey = this.options.privateCert || this.options.privateKey;
+  if(privateKey){
     if(!signingCert){
       throw new Error(
         "Missing signingCert while generating metadata for signing service provider messages");
     }
   }
 
-  if(this.options.decryptionPvk || this.options.privateCert){
+  if(this.options.decryptionPvk || privateKey){
     metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor=[];
-    if (this.options.privateCert) {
+    if (privateKey) {
 
       signingCert = signingCert.replace( /-+BEGIN CERTIFICATE-+\r?\n?/, '' );
       signingCert = signingCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );


### PR DESCRIPTION
I could be wrong, but I have never heard of a private certificate before. This confused my team quite a bit and i think it would be useful to correct this. I'm not claiming this is the optimal implementation, but starting this conversation would be great.