### PR TITLE
Always throw error objects instead of strings

### DIFF
--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -884,7 +884,7 @@ class SAML {
           });
 
           if (!hasValidQuerySignature) {
-            throw 'Invalid signature';
+            throw new Error('Invalid signature');
           }
         });
     } else {
@@ -906,7 +906,7 @@ class SAML {
       matchingAlgo = crypto.getHashes()[i];
     }
     else {
-      throw alg + ' is not supported';
+      throw new Error(alg + ' is not supported');
     }
 
     const verifier = crypto.createVerify(matchingAlgo);
@@ -931,7 +931,7 @@ class SAML {
     return (async () => {
       const statusCode = doc.LogoutResponse.Status[0].StatusCode[0].$.Value;
       if (statusCode !== "urn:oasis:names:tc:SAML:2.0:status:Success")
-        throw 'Bad status code: ' + statusCode;
+        throw new Error('Bad status code: ' + statusCode);
 
       this.verifyIssuer(doc.LogoutResponse);
       const inResponseTo = doc.LogoutResponse.$.InResponseTo;
@@ -948,9 +948,9 @@ class SAML {
       const issuer = samlMessage.Issuer;
       if (issuer) {
         if (issuer[0]._ !== this.options.idpIssuer)
-          throw 'Unknown SAML issuer. Expected: ' + this.options.idpIssuer + ' Received: ' + issuer[0]._;
+          throw new Error('Unknown SAML issuer. Expected: ' + this.options.idpIssuer + ' Received: ' + issuer[0]._);
       } else {
-        throw 'Missing SAML issuer';
+        throw new Error('Missing SAML issuer');
       }
     }
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -712,7 +712,7 @@ describe( 'passport-saml /', function() {
     it( 'should throw an error if cert property is provided to saml constructor but is empty', function() {
       should(function() {
         new SAML( { cert: null } );
-      }).throw({ message: 'Invalid property: cert must not be empty' });
+      }).throw('Invalid property: cert must not be empty');
     });
 
     it( 'generateUniqueID should generate 20 char IDs', function() {

--- a/test/tests.js
+++ b/test/tests.js
@@ -712,7 +712,7 @@ describe( 'passport-saml /', function() {
     it( 'should throw an error if cert property is provided to saml constructor but is empty', function() {
       should(function() {
         new SAML( { cert: null } );
-      }).throw('Invalid property: cert must not be empty');
+      }).throw({ message: 'Invalid property: cert must not be empty' });
     });
 
     it( 'generateUniqueID should generate 20 char IDs', function() {
@@ -2415,7 +2415,7 @@ describe( 'passport-saml /', function() {
         samlObj.validateRedirect(this.request, this.request.originalQuery, function(err) {
           try {
             should.exist(err);
-            err.should.eql(
+            err.message.should.eql(
               'Unknown SAML issuer. Expected: foo Received: http://localhost:20000/saml2/idp/metadata.php'
             );
             done();
@@ -2441,7 +2441,7 @@ describe( 'passport-saml /', function() {
         samlObj.validateRedirect(this.request, this.request.originalQuery, function(err) {
           try {
             should.exist(err);
-            err.should.eql('Invalid signature');
+            err.message.should.eql('Invalid signature');
             done();
           } catch (err2) {
             done(err2);
@@ -2499,7 +2499,7 @@ describe( 'passport-saml /', function() {
         samlObj.validateRedirect(this.request, this.request.originalQuery, function(err) {
           try {
             should.exist(err);
-            err.should.eql(
+            err.message.should.eql(
               'Unknown SAML issuer. Expected: foo Received: http://localhost:20000/saml2/idp/metadata.php'
             );
             done();
@@ -2513,7 +2513,7 @@ describe( 'passport-saml /', function() {
         samlObj.validateRedirect(this.request, this.request.originalQuery, function(err) {
           try {
             should.exist(err);
-            err.should.eql(
+            err.message.should.eql(
               'Bad status code: urn:oasis:names:tc:SAML:2.0:status:Requester'
             );
             done();
@@ -2539,7 +2539,7 @@ describe( 'passport-saml /', function() {
         samlObj.validateRedirect(this.request, this.request.originalQuery, function(err) {
           try {
             should.exist(err);
-            err.should.eql('Invalid signature');
+            err.message.should.eql('Invalid signature');
             done();
           } catch (err2) {
             done(err2);


### PR DESCRIPTION
While JS *technically* allows code to throw anything (including undefined/null/NaN), it's often considered bad practice. It's very annoying to handle/log errors from a library that sometimes throws strings and sometimes objects, and there's also no stack trace in string errors to help with debugging.

I realize this might be a controversial change, and it can break existing error handling code that assumes strings are thrown in some of the cases. But maybe it could be at least considered for 2.0?

More information:

https://eslint.org/docs/rules/no-throw-literal
http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-rejected-with-a-non-error