### PR TITLE
Allow overriding the authnRequestBinding option per IdP in the MultiSamlStrategy

### DIFF
--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -198,6 +198,8 @@ class SAML {
       options.RACComparison = "exact";
     }
 
+    options.authnRequestBinding = options.authnRequestBinding || "HTTP-Redirect";
+
     return options as SAMLOptions;
   }
 

--- a/src/passport-saml/strategy.ts
+++ b/src/passport-saml/strategy.ts
@@ -40,7 +40,6 @@ class Strategy extends PassportStrategy {
     this._verify = verify;
     this._saml = new saml.SAML(options);
     this._passReqToCallback = !!options.passReqToCallback;
-    this._authnRequestBinding = options.authnRequestBinding || "HTTP-Redirect";
   }
 
   authenticate(req: RequestWithUser, options: AuthenticateOptions & AuthorizeOptions): void {
@@ -101,7 +100,7 @@ class Strategy extends PassportStrategy {
     } else {
       const requestHandler = {
         "login-request": () => {
-          if (this._authnRequestBinding === "HTTP-POST") {
+          if (this._saml.options.authnRequestBinding === "HTTP-POST") {
             this._saml.getAuthorizeForm(req, (err: Error | null, data?: any) => {
               if (err) {
                 this.error(err);

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -45,6 +45,7 @@ export interface SAMLOptions {
   idpIssuer: string;
   audience: string;
   scoping: SamlScopingConfig;
+  authnRequestBinding?: string;
 
   // InResponseTo Validation
   validateInResponseTo: boolean;
@@ -67,7 +68,6 @@ export type SamlConfig = Partial<SAMLOptions> & StrategyOptions;
 interface StrategyOptions {
   name?: string;
   passReqToCallback?: boolean;
-  authnRequestBinding?: string;
 }
 
 export interface SamlScopingConfig {

--- a/test/multiSamlStrategy.js
+++ b/test/multiSamlStrategy.js
@@ -57,12 +57,10 @@ describe("strategy#authenticate", function () {
   it("passes options on to saml strategy", function (done) {
     var passportOptions = {
       passReqToCallback: true,
-      authnRequestBinding: "HTTP-POST",
       getSamlOptions: function (req, fn) {
         try {
           fn();
           strategy._passReqToCallback.should.eql(true);
-          strategy._authnRequestBinding.should.eql("HTTP-POST");
           done();
         } catch (err2) {
           done(err2);
@@ -137,12 +135,10 @@ describe("strategy#logout", function () {
   it("passes options on to saml strategy", function (done) {
     var passportOptions = {
       passReqToCallback: true,
-      authnRequestBinding: "HTTP-POST",
       getSamlOptions: function (req, fn) {
         try {
           fn();
           strategy._passReqToCallback.should.eql(true);
-          strategy._authnRequestBinding.should.eql("HTTP-POST");
           done();
         } catch (err2) {
           done(err2);
@@ -216,12 +212,10 @@ describe("strategy#generateServiceProviderMetadata", function () {
   it("passes options on to saml strategy", function (done) {
     var passportOptions = {
       passReqToCallback: true,
-      authnRequestBinding: "HTTP-POST",
       getSamlOptions: function (req, fn) {
         try {
           fn();
           strategy._passReqToCallback.should.eql(true);
-          strategy._authnRequestBinding.should.eql("HTTP-POST");
           done();
         } catch (err2) {
           done(err2);


### PR DESCRIPTION
Currently the `authnRequestBinding` configuration applies to all Identity Providers when using the `MultiSamlStrategy`.

This moves the option from the `Strategy` object to the `SAML` object so the `getSamlOptions` function from the `MultiSamlStrategy` can override it per Identity Provider.