### PR TITLE
Patch `strategy.js` for default values in `authenticate` method

### DIFF
--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -32,7 +32,7 @@ function Strategy (options, verify) {
 
 util.inherits(Strategy, passport.Strategy);
 
-Strategy.prototype.authenticate = function (req, options) {
+Strategy.prototype.authenticate = function (req, options = {}) {
   var self = this;
 
   options.samlFallback = options.samlFallback || 'login-request';


### PR DESCRIPTION
There is an error in passport and loopback 4 integration wherein `samlFallback` of undefined is not a function comes up. This is done to patch it