### PR TITLE
Provide default options value to authenticate function when not provided

### DIFF
--- a/lib/passport-saml/strategy.js
+++ b/lib/passport-saml/strategy.js
@@ -32,7 +32,7 @@ function Strategy (options, verify) {
 
 util.inherits(Strategy, passport.Strategy);
 
-Strategy.prototype.authenticate = function (req, options) {
+Strategy.prototype.authenticate = function (req, options = {name:'saml'}) {
   var self = this;
 
   options.samlFallback = options.samlFallback || 'login-request';


### PR DESCRIPTION
Fixes #424
https://github.com/node-saml/passport-saml/issues/424

Provided default options value to authenticate, when options are not provided.
Prevents error:
Cannot read property 'samlFallback' of undefined