### PR TITLE
fix host parameter is ignored

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -103,13 +103,12 @@ SAML.prototype.getCallbackUrl = function (req) {
   if (this.options.callbackUrl) {
     return this.options.callbackUrl;
   } else {
-    var host;
-    if (req.headers) {
-      host = req.headers.host;
-    } else {
-      host = this.options.host;
+    if(this.options.host) {
+      return this.options.host + this.options.path;
     }
-    return this.getProtocol(req) + host + this.options.path;
+    if (req.headers) {
+      return this.getProtocol(req) + req.headers.host + this.options.path;
+    } 
   }
 };
 


### PR DESCRIPTION
fix host parameter is ignored, mentioned in this issue: [#169](https://github.com/node-saml/passport-saml/issues/169)
