### PR TITLE
fix: add catch block to NameID decryption

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1154,6 +1154,9 @@ SAML.prototype.getNameID = function(self, doc, callback) {
           return callback(new Error('Invalid EncryptedAssertion content'));
         }
         return callBackWithNameID(decryptedIds[0], callback);
+      })
+      .catch(function (err) {
+        callback(err);
       });
   }
   callback(new Error('Missing SAML NameID'));

--- a/test/tests.js
+++ b/test/tests.js
@@ -2301,7 +2301,24 @@ describe( 'passport-saml /', function() {
         }
       });
     });
-	  it('errors if bad privateCert to requestToURL', function(done){
+  });
+  it('validatePostRequest errors for encrypted nameID with wrong decryptionPvk', function(done) {
+    var samlObj = new SAML({
+      cert: fs.readFileSync(__dirname + '/static/cert.pem', 'ascii'),
+      decryptionPvk: fs.readFileSync(__dirname + '/static/acme_tools_com.key', 'ascii')
+    });
+    var body = {
+      SAMLRequest: fs.readFileSync(__dirname + '/static/logout_request_with_encrypted_name_id.xml', 'base64')
+    };
+    samlObj.validatePostRequest(body, function(err) {
+      try {
+        should.exist(err);
+        done();
+      } catch (err2) {
+        done(err2);
+      }
+    });
+    it('errors if bad privateCert to requestToURL', function(done){
 		  var samlObj = new SAML({
               entryPoint: "foo",
               privateCert: "-----BEGIN CERTIFICATE-----\n"+


### PR DESCRIPTION
the callback invocation was being missed in case of errors during the NameID decryption 