### PR TITLE
Drop support for Node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "sinon": "^7.2.7"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 10"
   },
   "scripts": {
     "test": "npm run lint && mocha",


### PR DESCRIPTION
Node 8 LTS has been EOL since 2019-12-31. Current LTS is Node >=10, see: https://github.com/nodejs/Release.

Also the library doesn't build on Node 8: "error chalk@4.1.0: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.10.0""