### PR TITLE
Only make an attribute an object if it has child elements

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -1009,7 +1009,8 @@ SAML.prototype.processValidlySignedAssertion = function(xml, samlResponseXml, in
                                );
 
       var attrValueMapper = function(value) {
-        return value._ ? value._ : value;
+        const hasChildren = Object.keys(value).some((cur)=> { return (cur!=='_' && cur!=='$'); });
+        return (hasChildren) ? value : value._;
       };
 
       if (attributes) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1384,7 +1384,29 @@ describe( 'passport-saml /', function() {
         });
       });
 
-
+      it( 'An undefined value given with an object should still be undefined', function( done ) {
+        const xml = 
+        '<Response>' +
+          '<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0">' +
+            '<saml2:AttributeStatement>' +
+              '<saml2:Attribute Name="attributeName" ' +
+                  'NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">' +
+                '<saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" ' +
+                  'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+                  'xsi:type="xs:string"/>' +
+              '</saml2:Attribute>' +
+            '</saml2:AttributeStatement>' +
+          '</saml2:Assertion>' +
+        '</Response>';
+        var base64xml = Buffer.from( xml ).toString('base64');
+        var container = { SAMLResponse: base64xml };
+        var samlObj = new SAML();
+        samlObj.validatePostResponse( container, function( err, profile, logout ) {
+          should.not.exist( err );
+          should(profile['attributeName']).be.undefined();
+          done();
+        });
+      });
     });
 
     describe( 'getAuthorizeUrl request signature checks /', function() {


### PR DESCRIPTION
This PR

* Adds a test for an empty SAML AttributeValue, which should be represented as `undefined`
* Changes the `attrValueMapper` behaviour so that it returns the value of `_` (which will be the char value string or `undefined`) unless the SAML AttributeValue has child elements, in which case it returns the AttributeValue as an object.

Branch https://github.com/node-saml/passport-saml/tree/csh-issue-459-attr-value-regression-ec presents an alternative approach which would have wider impact/implications.

Closes #459 