### PR TITLE
compatibility with @types/passport-saml, fixes #475

### DIFF
--- a/src/passport-saml/index.ts
+++ b/src/passport-saml/index.ts
@@ -1,4 +1,6 @@
+import type { CacheItem, CacheProvider} from './inmemory-cache-provider';
 import { SAML } from './saml';
 import Strategy from './strategy';
+import type { Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from './types';
 
-export { SAML, Strategy };
+export { SAML, Strategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };

--- a/src/passport-saml/inmemory-cache-provider.ts
+++ b/src/passport-saml/inmemory-cache-provider.ts
@@ -13,7 +13,7 @@
  * @constructor
  */
 
-interface CacheValue {
+export interface CacheItem {
     value: string;
     createdAt: number;
 }
@@ -23,7 +23,7 @@ interface CacheProviderOptions {
 }
 
 export class CacheProvider {
-    cacheKeys: Record<string, CacheValue>;
+    cacheKeys: Record<string, CacheItem>;
     options: CacheProviderOptions;
 
     constructor(options: Partial<CacheProviderOptions>) {
@@ -63,7 +63,7 @@ export class CacheProvider {
      * @param id
      * @param value
      */
-    save(key: string, value: string, callback: (error: null, value: CacheValue) => void){
+    save(key: string, value: string, callback: (error: null, value: CacheItem) => void){
         if(!this.cacheKeys[key])
         {
             this.cacheKeys[key] = {

--- a/src/passport-saml/strategy.ts
+++ b/src/passport-saml/strategy.ts
@@ -122,4 +122,4 @@ Strategy.prototype.generateServiceProviderMetadata = function( decryptionCert, s
   return this._saml.generateServiceProviderMetadata( decryptionCert, signingCert );
 };
 
-export = Strategy;
+export = Strategy as any;

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -1,0 +1,73 @@
+import type express from 'express';
+import type { CacheProvider } from './inmemory-cache-provider';
+
+export type CertCallback = (callback: (err: Error | null, cert?: string | string[]) => void) => void;
+
+export interface SamlConfig {
+    // Core
+    callbackUrl?: string;
+    path?: string;
+    protocol?: string;
+    host?: string;
+    entryPoint?: string;
+    issuer?: string;
+    privateCert?: string;
+    cert?: string | string[] | CertCallback;
+    decryptionPvk?: string;
+    signatureAlgorithm?: 'sha1' | 'sha256' | 'sha512';
+
+    // Additional SAML behaviors
+    additionalParams?: any;
+    additionalAuthorizeParams?: any;
+    identifierFormat?: string;
+    acceptedClockSkewMs?: number;
+    attributeConsumingServiceIndex?: string;
+    disableRequestedAuthnContext?: boolean;
+    authnContext?: string;
+    forceAuthn?: boolean;
+    skipRequestCompression?: boolean;
+    authnRequestBinding?: string;
+    RACComparison?: 'exact' | 'minimum' | 'maximum' | 'better';
+    providerName?: string;
+    passive?: boolean;
+    idpIssuer?: string;
+    audience?: string;
+
+    // InResponseTo Validation
+    validateInResponseTo?: boolean;
+    requestIdExpirationPeriodMs?: number;
+    cacheProvider?: CacheProvider;
+
+    // Passport
+    name?: string;
+    passReqToCallback?: boolean;
+
+    // Logout
+    logoutUrl?: string;
+    additionalLogoutParams?: any;
+    logoutCallbackUrl?: string;
+}
+
+export type Profile = {
+    issuer?: string;
+    sessionIndex?: string;
+    nameID?: string;
+    nameIDFormat?: string;
+    nameQualifier?: string;
+    spNameQualifier?: string;
+    ID?: string;
+    mail?: string; // InCommon Attribute urn:oid:0.9.2342.19200300.100.1.3
+    email?: string; // `mail` if not present in the assertion
+    getAssertionXml(): string; // get the raw assertion XML
+    getAssertion(): Record<string, unknown>; // get the assertion XML parsed as a JavaScript object
+    getSamlResponseXml(): string; // get the raw SAML response XML
+  } & {
+    [attributeName: string]: unknown; // arbitrary `AttributeValue`s
+  };
+  
+export type VerifiedCallback = (err: Error | null, user?: Record<string, unknown>, info?: Record<string, unknown>) => void;
+
+export type VerifyWithRequest = (req: express.Request, profile: Profile, done: VerifiedCallback) => void;
+
+export type VerifyWithoutRequest = (profile: Profile, done: VerifiedCallback) => void;
+  


### PR DESCRIPTION
# Description
Before I did not include typings in package.json, but typescript still detects new definitions and turns off @types/passport-saml package

This PR adds compatibility with @types/passport-saml

 - Issue Addressed: [#475]
 - Tests included? [in #475]
