### PR TITLE
fix: disable esmoduleInterop setting

### DIFF
--- a/src/passport-saml/algorithms.ts
+++ b/src/passport-saml/algorithms.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import * as crypto from 'crypto';
 
 export function getSigningAlgorithm (shortName: string): string {
   switch(shortName) {

--- a/src/passport-saml/index.ts
+++ b/src/passport-saml/index.ts
@@ -1,6 +1,6 @@
 import type { CacheItem, CacheProvider} from './inmemory-cache-provider';
 import { SAML } from './saml';
-import Strategy from './strategy';
+import Strategy = require('./strategy');
 import type { Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from './types';
 
 export { SAML, Strategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };

--- a/src/passport-saml/multiSamlStrategy.ts
+++ b/src/passport-saml/multiSamlStrategy.ts
@@ -1,7 +1,7 @@
-import util from 'util';
+import * as util from 'util';
 import * as saml from './saml';
 import {CacheProvider as InMemoryCacheProvider} from './inmemory-cache-provider';
-import SamlStrategy from './strategy';
+import SamlStrategy = require('./strategy');
 
 function MultiSamlStrategy (options, verify) {
   if (!options || typeof options.getSamlOptions != 'function') {

--- a/src/passport-saml/strategy.ts
+++ b/src/passport-saml/strategy.ts
@@ -1,7 +1,7 @@
-import passport from 'passport-strategy';
-import util from 'util';
+import * as passport from 'passport-strategy';
+import * as util from 'util';
 import * as saml from './saml';
-import url from 'url';
+import * as url from 'url';
 import { AuthenticateOptions, AuthorizeOptions, SamlConfig, VerifyWithoutRequest, VerifyWithRequest } from './types';
 import type { Request } from 'express';
 import { Profile } from './types';

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -1,5 +1,5 @@
-import type express from 'express';
-import passport from 'passport';
+import type * as express from 'express';
+import * as passport from 'passport';
 import type { CacheProvider } from './inmemory-cache-provider';
 
 export type CertCallback = (callback: (err: Error | null, cert?: string | string[]) => void) => void;
@@ -73,10 +73,9 @@ export type Profile = {
   } & {
     [attributeName: string]: unknown; // arbitrary `AttributeValue`s
   };
-  
+
 export type VerifiedCallback = (err: Error | null, user?: Record<string, unknown>, info?: Record<string, unknown>) => void;
 
 export type VerifyWithRequest = (req: express.Request, profile: Profile, done: VerifiedCallback) => void;
 
 export type VerifyWithoutRequest = (profile: Profile, done: VerifiedCallback) => void;
-  

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 


### PR DESCRIPTION
This patch disables the `esmoduleInterop` setting that causes type issues when the library is used by applications that do not transform their code in this way.

Note the workaround for the `strategy.ts` file (import = require()) is not ideal, but the export in that file is not a valid ES export, so using this TS workaround to get past it.

fixes: #482