### PR TITLE
fix(typing): multi saml strategy typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-saml",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "license": "MIT",
   "keywords": [
     "saml",

--- a/src/passport-saml/index.ts
+++ b/src/passport-saml/index.ts
@@ -1,6 +1,7 @@
 import type { CacheItem, CacheProvider} from './inmemory-cache-provider';
 import { SAML } from './saml';
 import Strategy = require('./strategy');
+import MultiSamlStrategy = require('./multiSamlStrategy');
 import type { Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from './types';
 
-export { SAML, Strategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };
+export { SAML, Strategy, MultiSamlStrategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };

--- a/src/passport-saml/multiSamlStrategy.ts
+++ b/src/passport-saml/multiSamlStrategy.ts
@@ -66,4 +66,4 @@ MultiSamlStrategy.prototype.generateServiceProviderMetadata = function( req, dec
   });
 };
 
-module.exports = MultiSamlStrategy;
+export = MultiSamlStrategy as any;


### PR DESCRIPTION
Hi,

I made an fix to the typings for the MultiSamlStrategy based on the changes recently merged with PR #476 .
Without this fix the MultiSamlStrategy can't be imported in my Typescript project without an error.

Besides the fix as stated above I noticed the semver number isn't corresponding with the latest release (1.4.2 in the package.json file in contrast to the latest release 1.5.0). I updated the package.json to 1.5.0 so it contains at least the same version number as the latest release.