### PR TITLE
async/await for saml.ts

### DIFF
--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -1020,20 +1020,18 @@ class SAML {
     }
   }
 
-  verifyLogoutResponse(doc: XMLOutput) {
-    return (async () => {
-      const statusCode = doc.LogoutResponse.Status[0].StatusCode[0].$.Value;
-      if (statusCode !== "urn:oasis:names:tc:SAML:2.0:status:Success")
-        throw new Error('Bad status code: ' + statusCode);
+  async verifyLogoutResponse(doc: XMLOutput) {
+    const statusCode = doc.LogoutResponse.Status[0].StatusCode[0].$.Value;
+    if (statusCode !== "urn:oasis:names:tc:SAML:2.0:status:Success")
+      throw new Error('Bad status code: ' + statusCode);
 
-      this.verifyIssuer(doc.LogoutResponse);
-      const inResponseTo = doc.LogoutResponse.$.InResponseTo;
-      if (inResponseTo) {
-        return this.validateInResponseTo(inResponseTo);
-      }
+    this.verifyIssuer(doc.LogoutResponse);
+    const inResponseTo = doc.LogoutResponse.$.InResponseTo;
+    if (inResponseTo) {
+      return this.validateInResponseTo(inResponseTo);
+    }
 
-      return Promise.resolve(true);
-    })();
+    return true;
   }
 
   verifyIssuer(samlMessage: XMLOutput) {


### PR DESCRIPTION
To make saml.ts maintainable I've added async/await support for saml.ts

1. Old methods contain just `util.callbackify` function, which calls async `methodNameAsync` method
2. Old methods marked as deprecated (do we need to mark them this way?)

Pros:
* less useless code (no checks for errors, then, catch, helper functions to deal with promises and zlib.inflate). -95 lines if we don't count deprecated callback functions (-30 if we count them)
* the code left is written vertically, not diagonally
* better stack traces
Cons:
* too much changed for a single PR