### PR TITLE
Fix types on SAMLConfig to allow `privateKey`

### DIFF
--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -20,6 +20,10 @@ export interface SamlConfig {
     host?: string;
     entryPoint?: string;
     issuer?: string;
+    privateKey?: string;
+    /**
+     * @deprecated Use `privateKey` instead
+     */
     privateCert?: string;
     cert?: string | string[] | CertCallback;
     decryptionPvk?: string;


### PR DESCRIPTION
# Description

The docs say to use `privateKey` instead of `privateCert` but when I do that, I get a Typescript error. This should fix that issue.

# Checklist:

 - Issue Addressed: [X]
 - Link to SAML spec: [ ]
 - Tests included? [ ]
 - Documentation updated? [ ]
