### PR TITLE
fix(typing): multi saml stratey export

### DIFF
--- a/src/passport-saml/index.ts
+++ b/src/passport-saml/index.ts
@@ -1,6 +1,7 @@
 import type { CacheItem, CacheProvider} from './inmemory-cache-provider';
 import { SAML } from './saml';
 import Strategy = require('./strategy');
+import MultiSamlStrategy = require('./multiSamlStrategy');
 import type { Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from './types';
 
-export { SAML, Strategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };
+export { SAML, Strategy, MultiSamlStrategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };


### PR DESCRIPTION
# Description

A while ago I added PR #490 which was closed then because of the pending PR with a major Typescript refactor. After installing this refactor I still think the export of the MultiSamlStrategy class isn't complete. This PR adds the (in my opinion) missing export. Without this export, I have to import the MultiSamlStrategy from the deep located file 'passport-saml/lib/passport-saml/multiSamlStrategy' which causes the following TSLint error in my IDE: 

![image](https://user-images.githubusercontent.com/32069491/99665356-d5b0d280-2a69-11eb-916e-6558bc44d83a.png)

With the added export in this PR it is possible to do the import as following:

```javascript
import { MultiSamlStrategy } from 'passport-saml/lib/passport-saml';
```


