### PR TITLE
fix(typing): Export Multi SAML types

### DIFF
--- a/src/passport-saml/multiSamlStrategy.ts
+++ b/src/passport-saml/multiSamlStrategy.ts
@@ -3,13 +3,7 @@ import * as saml from './saml';
 import {CacheProvider as InMemoryCacheProvider} from './inmemory-cache-provider';
 import SamlStrategy = require('./strategy');
 import type { Request } from 'express';
-import { AuthenticateOptions, AuthorizeOptions, RequestWithUser, SamlConfig, VerifyWithoutRequest, VerifyWithRequest } from './types';
-
-type SamlOptionsCallback = (err: Error | null, samlOptions?: SamlConfig) => void;
-
-interface MultiSamlConfig extends SamlConfig {
-  getSamlOptions(req: Request, callback: SamlOptionsCallback): void;
-}
+import { AuthenticateOptions, AuthorizeOptions, MultiSamlConfig, RequestWithUser, VerifyWithoutRequest, VerifyWithRequest } from './types';
 
 class MultiSamlStrategy extends SamlStrategy {
   _options: MultiSamlConfig

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -135,3 +135,9 @@ export type VerifiedCallback = (err: Error | null, user?: Record<string, unknown
 export type VerifyWithRequest = (req: express.Request, profile: Profile | null | undefined, done: VerifiedCallback) => void;
 
 export type VerifyWithoutRequest = (profile: Profile | null | undefined, done: VerifiedCallback) => void;
+
+export type SamlOptionsCallback = (err: Error | null, samlOptions?: SamlConfig) => void;
+
+export interface MultiSamlConfig extends SamlConfig {
+  getSamlOptions(req: express.Request, callback: SamlOptionsCallback): void;
+}


### PR DESCRIPTION
# Description

A MultiSamlConfig has a getSamlOptions member, but its type is not exported. Exporting these typings allows TypeScript projects to reference the original definition.

For example:

```
import { MultiSamlStrategy } from "passport-saml";
import type { MultiSamlConfig, SamlOptionsCallback } from "passport-saml/lib/passport-saml/types";

function getSamlOptions(req: express.Request, done: SamlOptionsCallback): void {
  // Implementation
}
const config: MultiSamlConfig = { getSamlOptions };
const strategy: MultiSamlStrategy = new MultiSamlStrategy(config, verify);
```

# Checklist:

 - Issue Addressed: [ ]
 - Link to SAML spec: [ ]
 - Tests included? [ ]
 - Documentation updated? [ ]
