### PR TITLE
add ts-ignore to generated type definitions for multisaml strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint": "eslint --ext .ts src",
     "lint-watch": "onchange 'src/**/*.ts' -- eslint {{file}}",
     "lint:fix": "eslint --ext .ts --fix src",
-    "prepublishOnly": "tsc",
+    "prepare": "tsc",
     "prettier-check": "prettier --config .prettierrc --check .",
     "prettier-format": "prettier --config .prettierrc --write .",
     "prettier-watch": "onchange 'src/**/*.ts' -- prettier --write {{file}}",

--- a/src/passport-saml/multiSamlStrategy.ts
+++ b/src/passport-saml/multiSamlStrategy.ts
@@ -57,7 +57,7 @@ class MultiSamlStrategy extends SamlStrategy {
     });
   }
 
-  // @ts-expect-error typescript disallows changing method signature in a subclass
+  /** @ts-expect-error typescript disallows changing method signature in a subclass */
   generateServiceProviderMetadata(
     req: Request,
     decryptionCert: string | null,


### PR DESCRIPTION
# Description

1) Currently, we are forced to use ts-expect-error for multi-saml configuration because it extends the method in the base class with a completely different signature. But this ts-expect-error was not propagated to typescript definitions files. This PR makes things even worse - it uses undocumented feature of TS to propagate ts-expect-error in the definitions
2) to be able to use passport-saml from github I've changed tsc command from `prepublishonly` to `prepack` step. In this case tsc will run when package is installed directly from github

In v3 I suggest to change `generateServiceProviderMetadata` in multisaml strategy to `generateServiceProviderMetadataAsync` and add a stub with error message fro `generateServiceProviderMetadata`

# Checklist:

 - Issue Addressed: [ ]
 - Link to SAML spec: [ ]
 - Tests included? [ ]
 - Documentation updated? [ ]
