### PR TITLE
types: avoid ts-expect-error on generateServiceProviderMetadata

### DIFF
--- a/src/passport-saml/multiSamlStrategy.ts
+++ b/src/passport-saml/multiSamlStrategy.ts
@@ -57,18 +57,24 @@ class MultiSamlStrategy extends SamlStrategy {
     });
   }
 
-  /** @ts-expect-error typescript disallows changing method signature in a subclass */
+  generateServiceProviderMetadata( decryptionCert: string | null, signingCert?: string | null ): never
   generateServiceProviderMetadata(
     req: Request,
     decryptionCert: string | null,
     signingCert: string | null,
     callback: (err: Error | null, metadata?: string) => void
-  ) {
+  ): void
+  generateServiceProviderMetadata(
+    req: Request | string | null,
+    decryptionCert?: any,
+    signingCert?: any,
+    callback?: (err: Error | null, metadata?: string) => void
+  ): void {
     if (typeof callback !== 'function') {
       throw new Error("Metadata can't be provided synchronously for MultiSamlStrategy.");
     }
 
-    return this._options.getSamlOptions(req, (err, samlOptions) => {
+    return this._options.getSamlOptions(req as Request, (err, samlOptions) => {
       if (err) {
         return callback(err);
       }


### PR DESCRIPTION
# Description

In multiSamlStrategy, generateServiceProviderMetadata currently changes the signature from the base class, and uses a ts-expect-error so that compilation continues to work. However, the type files show errors because the subclass is no longer an instance of its base class.

This adds an overload to generateServiceProviderMetadata taking the original arguments and returning "never", while the implementation still checks the type of the callback to confirm we're using the right call.

# Checklist:

 - Issue Addressed: [x]
 - Link to SAML spec: [ ]
 - Tests included? [ ]
 - Documentation updated? [ ]
