### PR TITLE
fix: derive SamlConfig from SAMLOptions

### DIFF
--- a/src/passport-saml/saml-post-signing.ts
+++ b/src/passport-saml/saml-post-signing.ts
@@ -1,6 +1,6 @@
 import { SignedXml } from 'xml-crypto';
 import * as algorithms from './algorithms';
-import { SAMLOptions } from './saml';
+import { SAMLOptions } from './types';
 
 const authnRequestXPath = '/*[local-name(.)="AuthnRequest" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:protocol"]';
 const issuerXPath = '/*[local-name(.)="Issuer" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:assertion"]';

--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -102,41 +102,49 @@ function callBackWithNameID(nameid: Node, callback: (err: Error | null, value: N
 }
 
 export interface SAMLOptions {
-  scoping: SamlScopingConfig;
-  xmlSignatureTransforms: string[];
-  digestAlgorithm: string;
-  providerName: string;
-  attributeConsumingServiceIndex: string | null;
-  RACComparison: string;
-  authnContext: string | string[];
-  disableRequestedAuthnContext: boolean;
-  disableRequestACSUrl: boolean;
-  acceptedClockSkewMs: number;
+  callbackUrl: string;
+  path: string;
   protocol: string;
   host: string;
-  callbackUrl: string;
-  signatureAlgorithm: string;
-  path: string;
+  entryPoint: string;
+  issuer: string;
   privateCert?: string;
   privateKey: string;
-  logoutUrl: string;
-  entryPoint: string;
-  skipRequestCompression: boolean;
-  idpIssuer: string;
+  cert: string | string[] | CertCallback;
+  decryptionPvk: string;
+  signatureAlgorithm: string;
+
   additionalParams: Record<string, string>;
   additionalAuthorizeParams: Record<string, string>;
-  additionalLogoutParams: Record<string, string>;
-  cacheProvider: InMemoryCacheProvider;
-  issuer: string;
   identifierFormat: string;
-  cert: string | string[] | CertCallback;
+  acceptedClockSkewMs: number;
+  attributeConsumingServiceIndex: string | null;
+  disableRequestedAuthnContext: boolean;
+  authnContext: string | string[];
+  forceAuthn: boolean;
+  skipRequestCompression: boolean;
+  // no authnRequestBinding
+  RACComparison: string;
+  providerName: string;
   passive: boolean;
-  decryptionPvk: string;
-  logoutCallbackUrl: string;
+  idpIssuer: string;
+  audience: string;
+  scoping: SamlScopingConfig;
+
   validateInResponseTo: boolean;
   requestIdExpirationPeriodMs: number;
-  audience: string;
-  forceAuthn: boolean;
+  cacheProvider: InMemoryCacheProvider;
+
+  // no passport fields (name, passReqToCallback)
+
+  logoutUrl: string;
+  additionalLogoutParams: Record<string, string>;
+  logoutCallbackUrl: string;
+
+  // extras
+  xmlSignatureTransforms: string[];
+  digestAlgorithm: string;
+  disableRequestACSUrl: boolean;
 }
 
 

--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -24,6 +24,7 @@ import { AudienceRestrictionXML,
          LogoutRequestXML,
          Profile,
          RequestWithUser,
+         SAMLOptions,
          SamlIDPListConfig,
          SamlIDPEntryConfig,
          SamlScopingConfig,
@@ -100,53 +101,6 @@ function callBackWithNameID(nameid: Node, callback: (err: Error | null, value: N
     format: format && format[0] && format[0].nodeValue
   });
 }
-
-export interface SAMLOptions {
-  callbackUrl: string;
-  path: string;
-  protocol: string;
-  host: string;
-  entryPoint: string;
-  issuer: string;
-  privateCert?: string;
-  privateKey: string;
-  cert: string | string[] | CertCallback;
-  decryptionPvk: string;
-  signatureAlgorithm: string;
-
-  additionalParams: Record<string, string>;
-  additionalAuthorizeParams: Record<string, string>;
-  identifierFormat: string;
-  acceptedClockSkewMs: number;
-  attributeConsumingServiceIndex: string | null;
-  disableRequestedAuthnContext: boolean;
-  authnContext: string | string[];
-  forceAuthn: boolean;
-  skipRequestCompression: boolean;
-  // no authnRequestBinding
-  RACComparison: string;
-  providerName: string;
-  passive: boolean;
-  idpIssuer: string;
-  audience: string;
-  scoping: SamlScopingConfig;
-
-  validateInResponseTo: boolean;
-  requestIdExpirationPeriodMs: number;
-  cacheProvider: InMemoryCacheProvider;
-
-  // no passport fields (name, passReqToCallback)
-
-  logoutUrl: string;
-  additionalLogoutParams: Record<string, string>;
-  logoutCallbackUrl: string;
-
-  // extras
-  xmlSignatureTransforms: string[];
-  digestAlgorithm: string;
-  disableRequestACSUrl: boolean;
-}
-
 
 class SAML {
   options: SAMLOptions;

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -26,13 +26,13 @@ export interface SamlConfig {
     signatureAlgorithm?: 'sha1' | 'sha256' | 'sha512';
 
     // Additional SAML behaviors
-    additionalParams?: any;
-    additionalAuthorizeParams?: any;
+    additionalParams?: Record<string, string>;
+    additionalAuthorizeParams?: Record<string, string>;
     identifierFormat?: string;
     acceptedClockSkewMs?: number;
     attributeConsumingServiceIndex?: string | null;
     disableRequestedAuthnContext?: boolean;
-    authnContext?: string;
+    authnContext?: string | string[];
     forceAuthn?: boolean;
     skipRequestCompression?: boolean;
     authnRequestBinding?: string;
@@ -54,7 +54,7 @@ export interface SamlConfig {
 
     // Logout
     logoutUrl?: string;
-    additionalLogoutParams?: any;
+    additionalLogoutParams?: Record<string, string>;
     logoutCallbackUrl?: string;
 }
 

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -12,50 +12,60 @@ export interface AuthorizeOptions extends AuthenticateOptions {
   samlFallback?: 'login-request' | 'logout-request';
 }
 
-export interface SamlConfig {
+export interface SAMLOptions {
     // Core
-    callbackUrl?: string;
-    path?: string;
-    protocol?: string;
-    host?: string;
-    entryPoint?: string;
-    issuer?: string;
+    callbackUrl: string;
+    path: string;
+    protocol: string;
+    host: string;
+    entryPoint: string;
+    issuer: string;
+    /** @deprecated use privateKey field instead */
     privateCert?: string;
-    cert?: string | string[] | CertCallback;
-    decryptionPvk?: string;
-    signatureAlgorithm?: 'sha1' | 'sha256' | 'sha512';
+    privateKey: string;
+    cert: string | string[] | CertCallback;
+    decryptionPvk: string;
+    signatureAlgorithm: 'sha1' | 'sha256' | 'sha512';
 
     // Additional SAML behaviors
-    additionalParams?: Record<string, string>;
-    additionalAuthorizeParams?: Record<string, string>;
-    identifierFormat?: string;
-    acceptedClockSkewMs?: number;
-    attributeConsumingServiceIndex?: string | null;
-    disableRequestedAuthnContext?: boolean;
-    authnContext?: string | string[];
-    forceAuthn?: boolean;
-    skipRequestCompression?: boolean;
-    authnRequestBinding?: string;
-    RACComparison?: 'exact' | 'minimum' | 'maximum' | 'better';
-    providerName?: string;
-    passive?: boolean;
-    idpIssuer?: string;
-    audience?: string;
-    scoping? : SamlScopingConfig;
+    additionalParams: Record<string, string>;
+    additionalAuthorizeParams: Record<string, string>;
+    identifierFormat: string;
+    acceptedClockSkewMs: number;
+    attributeConsumingServiceIndex: string | null;
+    disableRequestedAuthnContext: boolean;
+    authnContext: string | string[];
+    forceAuthn: boolean;
+    skipRequestCompression: boolean;
+    RACComparison: 'exact' | 'minimum' | 'maximum' | 'better';
+    providerName: string;
+    passive: boolean;
+    idpIssuer: string;
+    audience: string;
+    scoping : SamlScopingConfig;
 
     // InResponseTo Validation
-    validateInResponseTo?: boolean;
-    requestIdExpirationPeriodMs?: number;
-    cacheProvider?: CacheProvider;
-
-    // Passport
-    name?: string;
-    passReqToCallback?: boolean;
+    validateInResponseTo: boolean;
+    requestIdExpirationPeriodMs: number;
+    cacheProvider: CacheProvider;
 
     // Logout
-    logoutUrl?: string;
-    additionalLogoutParams?: Record<string, string>;
-    logoutCallbackUrl?: string;
+    logoutUrl: string;
+    additionalLogoutParams: Record<string, string>;
+    logoutCallbackUrl: string;
+
+    // extras
+    xmlSignatureTransforms: string[];
+    digestAlgorithm: string;
+    disableRequestACSUrl: boolean;
+}
+
+export type SamlConfig = Partial<SAMLOptions> & StrategyOptions
+
+interface StrategyOptions {
+    name?: string;
+    passReqToCallback?: boolean;
+    authnRequestBinding?: string;
 }
 
 export interface SamlScopingConfig {


### PR DESCRIPTION
Strategy and MultiSamlStrategy accept an "options" parameter with three fields which are used locally by the strategy, and remaining fields which are passed on to the SAML constructor.

There was an issue where certain fields (e.g. `privateKey`) could not be passed to the Strategy constructor but had to be passed on to the SAML constructor. This fixes that more thoroughly than #497, also fixing the type of `authnContext`, the limited string parameters, and adding `xmlSignatureTransforms`, `digestAlgorithm` and `disableRequestACSUrl`. 

# Checklist:

 - Issue Addressed: [x]
 - Link to SAML spec: [ ]
 - Tests included? [ ]
 - Documentation updated? [ ]
