### PR TITLE
Reexport SamlConfig type to solve a regression in consumer packages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Description
 
-Thank you for taking the time to create a PR to support this commuity-maintained project. We are all volunteers here, so features are only added by contributers like you. Please also be patient while the maintainers work to review your proposed changes for quality and effacy.
+Thank you for taking the time to create a PR to support this community-maintained project. We are all volunteers here, so features are only added by contributers like you. Please also be patient while the maintainers work to review your proposed changes for quality and effacy.
 
 Please include a _summary of the change_ and, where appropriate, _which issue is addressed_.
 

--- a/src/passport-saml/index.ts
+++ b/src/passport-saml/index.ts
@@ -2,6 +2,6 @@ import type { CacheItem, CacheProvider} from './inmemory-cache-provider';
 import { SAML } from './saml';
 import Strategy = require('./strategy');
 import MultiSamlStrategy = require('./multiSamlStrategy');
-import type { Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from './types';
+import type { Profile, SamlConfig, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from './types';
 
-export { SAML, Strategy, MultiSamlStrategy, CacheItem, CacheProvider, Profile, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };
+export { SAML, Strategy, MultiSamlStrategy, CacheItem, CacheProvider, Profile, SamlConfig, VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest };


### PR DESCRIPTION
# Description

Quite similar to #476 
Maintainers of the @types/passport-saml package exported the `SamlConfig` type: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport-saml/index.d.ts#L39

Passport-SAML-Metadata (https://github.com/compwright/passport-saml-metadata) which depends on this package@latest and, more importantly, its types were referring to that interface.
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport-saml-metadata/src/metadata.d.ts
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/passport-saml-metadata/src/passport.d.ts
(Never mind my own code using this interface for convenience reasons as well.)

Re-Exporting the `SamlConfig` interface will resolve TypeScript compilation issues.

# Checklist:

 - Issue Addressed: [x]
 This really is #475 all over again.
 - Link to SAML spec: [x]
 - Tests included? [x]
 (I didn't plug in any, as TSC was ignoring the `test` folder, but if you feel this should be solved sooner rather than later)
 - Documentation updated? [x]
