### PR TITLE
dev: add @types/xml-encryption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -471,6 +471,15 @@
         "xpath": "0.0.27"
       }
     },
+    "@types/xml-encryption": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.0.tgz",
+      "integrity": "sha512-+/QeXG3B0Z7aC6Dm+TvGkhWUuMVJczhA1+6gSwp0Rf14G+miy9IBLxC2s/o13271aHVo3DPqPOCI1YG8+0DnCg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/xml2js": {
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/node": "^14.14.13",
     "@types/passport-strategy": "^0.2.35",
     "@types/xml-crypto": "^1.4.1",
+    "@types/xml-encryption": "^1.2.0",
     "@types/xml2js": "^0.4.7",
     "@types/xmldom": "^0.1.30",
     "@typescript-eslint/eslint-plugin": "^4.9.1",

--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -8,7 +8,6 @@ import * as xmldom from 'xmldom';
 import * as url from 'url';
 import * as querystring from 'querystring';
 import * as xmlbuilder from 'xmlbuilder';
-// @ts-expect-error no typings for xml-encryption
 import * as xmlenc from 'xml-encryption';
 import * as util from 'util';
 import {CacheProvider as InMemoryCacheProvider} from './inmemory-cache-provider';


### PR DESCRIPTION
# Description

I noticed that you were ignoring errors from `xml-encryption` not having types. `xml-encryption` now has types, so those can be used instead.

# Checklist:

 - Issue Addressed: [x]
 - Link to SAML spec: [ ]
 - Tests included? [ ]
 - Documentation updated? [ ]
