### PR TITLE
Fix typing export for MultiSAMLStrategy

### DIFF
--- a/multiSamlStrategy.d.ts
+++ b/multiSamlStrategy.d.ts
@@ -1,2 +1,2 @@
-import * as MultiSAMLStrategy from "./lib/passport-saml/multiSamlStrategy";
+import MultiSAMLStrategy = require("./lib/passport-saml/multiSamlStrategy");
 export = MultiSAMLStrategy;


### PR DESCRIPTION
otherwise `tsc` will complain about nonsense import when used in a project

``` 
node_modules/passport-saml/multiSamlStrategy.d.ts:1:36 - error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'esModuleInterop' flag and referencing its default export.

1 import * as MultiSAMLStrategy from './lib/passport-saml/multiSamlStrategy';
```
