### PR TITLE
Update readme on using multiSamlStrategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The examples utilize the [Feide OpenIdp identity provider](https://openidp.feide
 The SAML identity provider will redirect you to the URL provided by the `path` configuration.
 
 ```javascript
-var SamlStrategy = require('passport-saml').Strategy;
+const SamlStrategy = require('passport-saml').Strategy;
 [...]
 
 passport.use(new SamlStrategy(
@@ -48,7 +48,7 @@ passport.use(new SamlStrategy(
 You can pass a `getSamlOptions` parameter to `MultiSamlStrategy` which will be called before the SAML flows. Passport-SAML will pass in the request object so you can decide which configuation is appropriate.
 
 ```javascript
-var MultiSamlStrategy = require('passport-saml/multiSamlStrategy');
+const { MultiSamlStrategy } = require('passport-saml');
 [...]
 
 passport.use(new MultiSamlStrategy(

--- a/multiSamlStrategy.d.ts
+++ b/multiSamlStrategy.d.ts
@@ -1,2 +1,0 @@
-import * as MultiSAMLStrategy from "./lib/passport-saml/multiSamlStrategy";
-export = MultiSAMLStrategy;

--- a/multiSamlStrategy.js
+++ b/multiSamlStrategy.js
@@ -1,2 +1,0 @@
-const MultiSamlStrategy = require("./lib/passport-saml/multiSamlStrategy.js");
-module.exports = MultiSamlStrategy;

--- a/test/multiSamlStrategy.js
+++ b/test/multiSamlStrategy.js
@@ -3,7 +3,7 @@
 var sinon = require("sinon");
 var should = require("should");
 var SamlStrategy = require("../lib/passport-saml/index.js").Strategy;
-var MultiSamlStrategy = require("../multiSamlStrategy");
+var MultiSamlStrategy = require("../lib/passport-saml/multiSamlStrategy");
 
 function verify() {}
 


### PR DESCRIPTION
passport-saml/multiSamlStrategy.js is something I'd like to remove:
1. it contains nothing, just import
2. it is outside of the source root and tsc/other tools don't include this file
3. old import depends on internal structure of the project
4. it uses module-level export

For now let's keep the file for compatibility, but let's update README so new people will not use the old way
