### PR TITLE
Messed up with a valid response and it still tests as valid.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 yarn-error.log
 .DS_Store 
 .eslintcache
+.vscode

--- a/test/static/signatures/invalid/response.root-invalidly-signed.assertion-signed.xml
+++ b/test/static/signatures/invalid/response.root-invalidly-signed.assertion-signed.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Destination="https://evil-corp.madness.com/sso/callback" ID="_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" InResponseTo="_e8df3fe5f04237d25670" IssueInstant="2015-08-31T08:54:06+00:00" Version="2.0">
+    <saml:Issuer>https://hacker-corp.com</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:Assertion ID="_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" IssueInstant="2020-09-25T16:00:00+00:00" Version="2.0">
+        <saml:Issuer>https://evil-corp.com</saml:Issuer>
+        <saml:Subject>
+            <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">vincent.vega@evil-corp.com
+            </saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml:SubjectConfirmationData InResponseTo="_e8df3fe5f04237d25670" NotOnOrAfter="2020-09-25T16=7:00:00+00:00" Recipient="https://evil-corp.madness.com/sso/callback"/>
+            </saml:SubjectConfirmation>
+        </saml:Subject>
+        <saml:Conditions NotBefore="2020-09-25T16:00:00+00:00" NotOnOrAfter="2020-09-25T17:00:00+00:00"/>
+        <saml:AuthnStatement AuthnInstant="2020-09-25T16:00:00+00:00" SessionIndex="_9e315bdf7b1b6732be33c377cf6f5c4f">
+            <saml:AuthnContext>
+                <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport
+                </saml:AuthnContextClassRef>
+            </saml:AuthnContext>
+        </saml:AuthnStatement>
+        <saml:AttributeStatement>
+            <saml:Attribute Name="evil-corp.egroupid">
+                <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">
+                    vincent.vega@evil-corp.com
+                </saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute Name="evilcorp.givenname">
+                <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">Vincent
+                </saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute Name="evilcorp.sn">
+                <saml:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">VEGA
+                </saml:AttributeValue>
+            </saml:Attribute>
+        </saml:AttributeStatement>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo>
+                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </ds:Transforms>
+                    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>yFyp0ukUesUFin+8yRA2Ldw7F4vJtnHIUaCd+iwswtE=</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>GXh443ZANwMWTpdn5Yx8Drlx3iuxM7UvQG5Qtw7wJ2GuNaaiR8rhsAvcxWPFhivOEhahS3j8JRAxSpkfB7F/hei3IkKCa21q+gSwfnSjTsFWkicKMTFT575Dq1ucBMir3bAPKjSk282j2NDy7dK6SZMrTd7ilxxEK+ihnLJnk2U2ezqUztEdJwo+t10SXRPQqkIawqCAOCLMT1PrvkjF9hJsFnV9RQRJH7vlB5eWttie+VUYXtzPeh8ZFCKP8aXfj/YPUx6C49EU16JK0UUApdi2bzHAOTMKAAl1L+ul/rlpS/oNwYWtbOWA/yZbgBXLG4oJUQR3zFXPyu7gV0K1Fg==</ds:SignatureValue>
+        </ds:Signature>
+    </saml:Assertion>
+    <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <ds:SignedInfo>
+            <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+            <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <ds:Reference URI="#_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">
+                <ds:Transforms>
+                    <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                    <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                </ds:Transforms>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>pUbHXQ1WaHtmlrr02h5L59TD4yPouUCTUMinVxyj5R4=</ds:DigestValue>
+            </ds:Reference>
+        </ds:SignedInfo>
+        <ds:SignatureValue>tm/5eCuuiPlC0jlRNqMv4ReNpn4Ss3CekShExbXcMpP7odyrCYmlks7BwB5VH3GNaSqRlOM6mGHLJw32cfo7nYNDZo2fJutdegUwwhfbCJ9MwoJH1nE/eHnknxIaXQv6fSxA9uVeGBlAG1f7S/3lJ+94zMDcxydElotigOyLp2F4INBXl/fzbDgLAVdeMkyUjy+3Kv2pNY8KNcAnRateKnmtFskBq48bidXLFNYeLpsV1t7vj+tUef9+mRxMsHE5PzrQ2bvm3I/k6nmg/WEy5Hnyz5oGKxKH/3boYALMH94fy0hhALm8LQ0DwJxLrX6F0pxyXr+QuVpAPLDqSh32Jg==</ds:SignatureValue>
+    </ds:Signature>
+</samlp:Response>

--- a/test/static/signatures/invalid/response.root-invalidly-signed.assertion-signed.xml
+++ b/test/static/signatures/invalid/response.root-invalidly-signed.assertion-signed.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Destination="https://evil-corp.madness.com/sso/callback" ID="_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" InResponseTo="_e8df3fe5f04237d25670" IssueInstant="2015-08-31T08:54:06+00:00" Version="2.0">
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Destination="https://hacker-corp.madness.com/sso/callback" ID="_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" InResponseTo="_e8df3fe5f04237d25670" IssueInstant="2015-08-31T08:54:06+00:00" Version="2.0">
     <saml:Issuer>https://hacker-corp.com</saml:Issuer>
     <samlp:Status>
         <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>

--- a/test/test-signatures.spec.ts
+++ b/test/test-signatures.spec.ts
@@ -74,6 +74,14 @@ describe("Signatures", function () {
       testOneResponse("/invalid/response.root-signed.assertion-signed.xml", INVALID_SIGNATURE, 2)
     );
     it(
+      "R1A - both signed with invalid root signature => error",
+      testOneResponse(
+        "/invalid/response.root-invalidly-signed.assertion-signed.xml",
+        INVALID_SIGNATURE,
+        2
+      )
+    );
+    it(
       "R1A - root signed => error",
       testOneResponse("/invalid/response.root-signed.assertion-unsigned.xml", INVALID_SIGNATURE, 2)
     );


### PR DESCRIPTION
# Description

I am unsure if this new test shows a bug in the response validation.

For this test I copied the valid response `valid/response.root-signed.assertion-signed.xml` and replaced the text "https://evil-corp.com" for "https://hacker-corp.com".
I placed this invalid response in `invalid/response.root-invalidly-signed.assertion-signed.xml`.

This new file should be an invalid response (because I have tempered with the contents).
Therefore the test should result in "Invalid signature", but what it does return is: "SAML assertion expired".

Is this an error, or am I missing something here?

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ ]
- Tests included? [x]
- Documentation updated? [ ]
