### PR TITLE
bump xmldom to 0.5.x since all lower versions have security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-saml",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9277,9 +9277,9 @@
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="
     },
     "xmldom": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
-      "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xpath": {
       "version": "0.0.27",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-saml",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "SAML 2.0 authentication strategy for Passport",
   "keywords": [
     "saml",
@@ -56,7 +56,7 @@
     "xml-encryption": "1.2.1",
     "xml2js": "^0.4.23",
     "xmlbuilder": "^15.1.1",
-    "xmldom": "0.4.x"
+    "xmldom": "0.5.x"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",


### PR DESCRIPTION
# Description

xmldom versions <= 0.4.0 have security issue. Update xmldom dependency to 0.5.x and bump package version. 
More information: https://github.com/xmldom/xmldom/security/advisories/GHSA-h6q6-9hqw-rwfv

 After this fix as been merged, a new version of passport-saml should be released to npm. 