### PR TITLE
Fix lint npm script to match all files including in src/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 yarn-error.log
 .DS_Store 
 .eslintcache
+.dir-locals.el

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "build": "tsc",
     "changelog": "gren changelog --override --generate",
-    "lint": "eslint --ext .ts **/*.ts --cache",
+    "lint": "eslint --ext .ts \"**/*.ts\" --cache",
     "lint-watch": "onchange -k -p 100 \"**/*.ts\" -- eslint {{file}}",
     "lint:fix": "eslint --ext .ts --fix src",
     "prepare": "tsc",


### PR DESCRIPTION
# Description

The current lint rule misses most of the interesting lint errors (in src/) :)