### PR TITLE
Update xml-encryption to v1.2.3 (branch 2.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -760,6 +760,7 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
       "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dev": true,
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -2073,7 +2074,8 @@
     "follow-redirects": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
-      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2182,6 +2184,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/github-api/-/github-api-3.4.0.tgz",
       "integrity": "sha512-2yYqYS6Uy4br1nw0D3VrlYWxtGTkUhIZrumBrcBwKdBOzMT8roAe8IvI6kjIOkxqxapKR5GkEsHtz3Du/voOpA==",
+      "dev": true,
       "requires": {
         "axios": "^0.21.1",
         "debug": "^2.2.0",
@@ -2193,6 +2196,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -2200,7 +2204,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2943,7 +2948,8 @@
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "dev": true
     },
     "js-beautify": {
       "version": "1.13.0",
@@ -8835,7 +8841,8 @@
     "utf8": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+      "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -9089,21 +9096,14 @@
       }
     },
     "xml-encryption": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.1.tgz",
-      "integrity": "sha512-hn5w3l5p2+nGjlmM0CAhMChDzVGhW+M37jH35Z+GJIipXbn9PUlAIRZ6I5Wm7ynlqZjFrMAr83d/CIp9VZJMTA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.3.tgz",
+      "integrity": "sha512-oVZIicsZM1VobJ5Hxxgh2ovglIY2ZuXFTeZHmJSV7hABvgkD20PSy4G+qwRToQCkagymS1zJU2XV4wjkoCS9mQ==",
       "requires": {
         "escape-html": "^1.0.3",
         "node-forge": "^0.10.0",
-        "xmldom": "~0.1.15",
+        "xmldom": "~0.5.0",
         "xpath": "0.0.27"
-      },
-      "dependencies": {
-        "xmldom": {
-          "version": "0.1.31",
-          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-          "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
-        }
       }
     },
     "xml2js": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "debug": "^4.3.1",
     "passport-strategy": "*",
     "xml-crypto": "^2.1.1",
-    "xml-encryption": "1.2.1",
+    "xml-encryption": "^1.2.3",
     "xml2js": "^0.4.23",
     "xmlbuilder": "^15.1.1",
     "xmldom": "0.5.x"


### PR DESCRIPTION
This time no `npm dedup` which seems to mess things up for some reasons. 