### PR TITLE
Add deprecation notices for renamed variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ type Profile = {
   * `providerName`: optional human-readable name of the requester for use by the presenter's user agent or the identity provider
   * `skipRequestCompression`: if set to true, the SAML request from the service provider won't be compressed.
   * `authnRequestBinding`: if set to `HTTP-POST`, will request authentication from IDP via HTTP POST binding, otherwise defaults to HTTP Redirect
-  * `disableRequestACSUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
+  * `disableRequestAcsUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
   * `scoping`: An optional configuration which implements the functionality [explained in the SAML spec paragraph "3.4.1.2 Element <Scoping>"](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). The config object is structured as following:
 ```javascript
 {

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ type Profile = {
   * `attributeConsumingServiceIndex`: optional `AttributeConsumingServiceIndex` attribute to add to AuthnRequest to instruct the IDP which attribute set to attach to the response ([link](http://blog.aniljohn.com/2014/01/data-minimization-front-channel-saml-attribute-requests.html))
   * `disableRequestedAuthnContext`: if truthy, do not request a specific authentication context. This is [known to help when authenticating against Active Directory](https://github.com/node-saml/passport-saml/issues/226) (AD FS) servers.
   * `authnContext`: if truthy, name identifier format to request auth context (default: `urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport`); array of values is also supported
-  * `RACComparison`: Requested Authentication Context comparison type. Possible values are 'exact','minimum','maximum','better'. Default is 'exact'.
+  * `racComparison`: Requested Authentication Context comparison type. Possible values are 'exact','minimum','maximum','better'. Default is 'exact'.
 
   * `forceAuthn`: if set to true, the initial SAML request from the service provider specifies that the IdP should force re-authentication of the user, even if they possess a valid session.
   * `providerName`: optional human-readable name of the requester for use by the presenter's user agent or the identity provider

--- a/docs/adfs/README.md
+++ b/docs/adfs/README.md
@@ -57,7 +57,7 @@ passport.use(new SamlStrategy(
     identifierFormat: null,
   // this is configured under the Advanced tab in AD FS relying party
     signatureAlgorithm: 'sha256',
-    RACComparison: 'exact', // default to exact RequestedAuthnContext Comparison Type
+    racComparison: 'exact', // default to exact RequestedAuthnContext Comparison Type
   },
   function(profile, done) {
     return done(null,

--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -122,6 +122,14 @@ class SAML {
       }
     }
 
+    if (options.RACComparison) {
+      console.warn("options.RACComparison has been deprecated; use options.racComparison instead.")
+
+      if (!options.racComparison) {
+        options.racComparison = options.RACComparison;
+      }
+    }
+
     if (Object.prototype.hasOwnProperty.call(options, 'cert') && !options.cert) {
       throw new Error('Invalid property: cert must not be empty');
     }
@@ -185,8 +193,8 @@ class SAML {
      * - maximum:  Assertion context must be no stronger than a context in the list
      * - better:  Assertion context must be stronger than all contexts in the list
      */
-    if (!options.RACComparison || ['exact','minimum','maximum','better'].indexOf(options.RACComparison) === -1){
-      options.RACComparison = 'exact';
+    if (!options.racComparison || ['exact','minimum','maximum','better'].indexOf(options.racComparison) === -1){
+      options.racComparison = 'exact';
     }
 
     return options as SAMLOptions;
@@ -297,7 +305,7 @@ class SAML {
 
         request['samlp:AuthnRequest']['samlp:RequestedAuthnContext'] = {
           '@xmlns:samlp': 'urn:oasis:names:tc:SAML:2.0:protocol',
-          '@Comparison': this.options.RACComparison,
+          '@Comparison': this.options.racComparison,
           'saml:AuthnContextClassRef': authnContextClassRefs
         };
       }

--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -117,7 +117,7 @@ class SAML {
     if (options.privateCert) {
       console.warn("options.privateCert has been deprecated; use options.privateKey instead.");
 
-      if (!options.privateKey) {
+      if (options.privateKey == null) {
         options.privateKey = options.privateCert;
       }
     }
@@ -125,7 +125,7 @@ class SAML {
     if (options.RACComparison) {
       console.warn("options.RACComparison has been deprecated; use options.racComparison instead.")
 
-      if (!options.racComparison) {
+      if (options.racComparison == null) {
         options.racComparison = options.RACComparison;
       }
     }
@@ -133,7 +133,7 @@ class SAML {
     if (options.disableRequestACSUrl) {
       console.warn("options.disableRequestACSUrl has been deprecated; use options.disableRequestAcsUrl instead.")
 
-      if (!options.disableRequestAcsUrl) {
+      if (options.disableRequestAcsUrl == null) {
         options.disableRequestAcsUrl = options.disableRequestACSUrl;
       }
     }

--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -130,6 +130,14 @@ class SAML {
       }
     }
 
+    if (options.disableRequestACSUrl) {
+      console.warn("options.disableRequestACSUrl has been deprecated; use options.disableRequestAcsUrl instead.")
+
+      if (!options.disableRequestAcsUrl) {
+        options.disableRequestAcsUrl = options.disableRequestACSUrl;
+      }
+    }
+
     if (Object.prototype.hasOwnProperty.call(options, 'cert') && !options.cert) {
       throw new Error('Invalid property: cert must not be empty');
     }
@@ -282,7 +290,7 @@ class SAML {
         request['samlp:AuthnRequest']['@ForceAuthn'] = true;
       }
 
-      if (!this.options.disableRequestACSUrl) {
+      if (!this.options.disableRequestAcsUrl) {
         request['samlp:AuthnRequest']['@AssertionConsumerServiceURL'] = this.getCallbackUrl(req);
       }
 

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -37,6 +37,7 @@ export interface SAMLOptions {
     authnContext: string | string[];
     forceAuthn: boolean;
     skipRequestCompression: boolean;
+    racComparison: 'exact' | 'minimum' | 'maximum' | 'better';
     RACComparison: 'exact' | 'minimum' | 'maximum' | 'better';
     providerName: string;
     passive: boolean;

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -37,8 +37,9 @@ export interface SAMLOptions {
     authnContext: string | string[];
     forceAuthn: boolean;
     skipRequestCompression: boolean;
+    /** @deprecated use racComparison field instead */
+    RACComparison?: 'exact' | 'minimum' | 'maximum' | 'better';
     racComparison: 'exact' | 'minimum' | 'maximum' | 'better';
-    RACComparison: 'exact' | 'minimum' | 'maximum' | 'better';
     providerName: string;
     passive: boolean;
     idpIssuer: string;
@@ -58,7 +59,9 @@ export interface SAMLOptions {
     // extras
     xmlSignatureTransforms: string[];
     digestAlgorithm: string;
-    disableRequestACSUrl: boolean;
+    /** @deprecated use disableRequestAcsUrl field instead */
+    disableRequestACSUrl?: boolean;
+    disableRequestAcsUrl: boolean;
 }
 
 export type SamlConfig = Partial<SAMLOptions> & StrategyOptions

--- a/test/tests.js
+++ b/test/tests.js
@@ -512,7 +512,7 @@ describe( 'passport-saml /', function() {
       config: {
         identifierFormat: null,
         disableRequestedAuthnContext: true,
-        disableRequestACSUrl: true,
+        disableRequestAcsUrl: true,
       },
       result: {
         'samlp:AuthnRequest':

--- a/test/tests.js
+++ b/test/tests.js
@@ -2247,14 +2247,14 @@ describe( 'passport-saml /', function() {
         additionalLogoutParams.should.containEql({'queryParam': 'queryParamRuntimeValue'});
       });
 
-      it('should check the value of the option `RACComparison`', function() {
-        var samlObjBadComparisonType = new SAML({ RACComparison: 'bad_value' });
-        should.equal(samlObjBadComparisonType.options.RACComparison, 'exact', ['the default value of the option `RACComparison` must be exact']);
+      it('should check the value of the option `racComparison`', function() {
+        var samlObjBadComparisonType = new SAML({ racComparison: 'bad_value' });
+        should.equal(samlObjBadComparisonType.options.racComparison, 'exact', ['the default value of the option `racComparison` must be exact']);
 
         var validComparisonTypes = ['exact','minimum','maximum','better'], samlObjValidComparisonType;
-        validComparisonTypes.forEach(function(RACComparison) {
-            samlObjValidComparisonType = new SAML( {RACComparison: RACComparison} );
-            should.equal(samlObjValidComparisonType.options.RACComparison, RACComparison);
+        validComparisonTypes.forEach(function(racComparison) {
+            samlObjValidComparisonType = new SAML( {racComparison: racComparison} );
+            should.equal(samlObjValidComparisonType.options.racComparison, racComparison);
         });
       });
     });


### PR DESCRIPTION
This simply renames option names and adds deprecation notices to help people prepare for 3.x

- disableRequestACSUrl -> disableRequestAcsUrl
- RACComparison -> racComparison