### PR TITLE
Move XML functions to utility module

### DIFF
--- a/src/node-saml/saml-post-signing.ts
+++ b/src/node-saml/saml-post-signing.ts
@@ -1,42 +1,19 @@
-import { SignedXml } from "xml-crypto";
-import * as algorithms from "./algorithms";
 import { SamlSigningOptions } from "./types";
+import { signXml } from "./xml";
 
 const authnRequestXPath =
   '/*[local-name(.)="AuthnRequest" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:protocol"]';
 const issuerXPath =
   '/*[local-name(.)="Issuer" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:assertion"]';
-const defaultTransforms = [
-  "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
-  "http://www.w3.org/2001/10/xml-exc-c14n#",
-];
 
 export function signSamlPost(
   samlMessage: string,
   xpath: string,
   options: SamlSigningOptions
 ): string {
-  if (!samlMessage) throw new Error("samlMessage is required");
-  if (!xpath) throw new Error("xpath is required");
-  if (!options) {
-    options = {} as SamlSigningOptions;
-  }
-
-  if (options.privateKey == null) throw new Error("options.privateKey is required");
-
-  const transforms = options.xmlSignatureTransforms || defaultTransforms;
-  const sig = new SignedXml();
-  if (options.signatureAlgorithm) {
-    sig.signatureAlgorithm = algorithms.getSigningAlgorithm(options.signatureAlgorithm);
-  }
-  sig.addReference(xpath, transforms, algorithms.getDigestAlgorithm(options.digestAlgorithm));
-  sig.signingKey = options.privateKey;
-  sig.computeSignature(samlMessage, {
-    location: { reference: xpath + issuerXPath, action: "after" },
-  });
-  return sig.getSignedXml();
+  return signXml(samlMessage, xpath, { reference: xpath + issuerXPath, action: "after" }, options);
 }
 
-export function signAuthnRequestPost(authnRequest: string, options: SamlSigningOptions) {
+export function signAuthnRequestPost(authnRequest: string, options: SamlSigningOptions): string {
   return signSamlPost(authnRequest, authnRequestXPath, options);
 }

--- a/src/node-saml/saml.ts
+++ b/src/node-saml/saml.ts
@@ -10,6 +10,7 @@ import * as algorithms from "./algorithms";
 import { signAuthnRequestPost } from "./saml-post-signing";
 import { ParsedQs } from "qs";
 import {
+  isValidSamlSigningOptions,
   AudienceRestrictionXML,
   AuthorizeRequestXML,
   CertCallback,
@@ -355,7 +356,8 @@ class SAML {
     }
 
     let stringRequest = buildXmlBuilderObject(request, false);
-    if (isHttpPostBinding && this.options.privateKey != null) {
+    // TODO: maybe we should always sign here
+    if (isHttpPostBinding && isValidSamlSigningOptions(this.options)) {
       stringRequest = signAuthnRequestPost(stringRequest, this.options);
     }
     return stringRequest;

--- a/src/node-saml/saml.ts
+++ b/src/node-saml/saml.ts
@@ -4,7 +4,6 @@ import * as zlib from "zlib";
 import * as crypto from "crypto";
 import { URL } from "url";
 import * as querystring from "querystring";
-import * as xmlbuilder from "xmlbuilder";
 import * as util from "util";
 import { CacheProvider as InMemoryCacheProvider } from "./inmemory-cache-provider";
 import * as algorithms from "./algorithms";
@@ -33,6 +32,7 @@ import {
 import { assertRequired } from "./utility";
 import {
   buildXml2JsObject,
+  buildXmlBuilderObject,
   decryptXml,
   parseDomFromString,
   parseXml2JsFromString,
@@ -354,7 +354,7 @@ class SAML {
       request["samlp:AuthnRequest"]["samlp:Scoping"] = scoping;
     }
 
-    let stringRequest = xmlbuilder.create((request as unknown) as Record<string, any>).end();
+    let stringRequest = buildXmlBuilderObject(request, false);
     if (isHttpPostBinding && this.options.privateKey != null) {
       stringRequest = signAuthnRequestPost(stringRequest, this.options);
     }
@@ -400,7 +400,7 @@ class SAML {
     }
 
     await this.cacheProvider.saveAsync(id, instant);
-    return xmlbuilder.create((request as unknown) as Record<string, any>).end();
+    return buildXmlBuilderObject(request, false);
   }
 
   _generateLogoutResponse(logoutRequest: Profile) {
@@ -427,7 +427,7 @@ class SAML {
       },
     };
 
-    return xmlbuilder.create(request).end();
+    return buildXmlBuilderObject(request, false);
   }
 
   async _requestToUrlAsync(
@@ -1379,9 +1379,7 @@ class SAML {
       "@Binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
       "@Location": this.getCallbackUrl(),
     };
-    return xmlbuilder
-      .create((metadata as unknown) as Record<string, any>)
-      .end({ pretty: true, indent: "  ", newline: "\n" });
+    return buildXmlBuilderObject(metadata, true);
   }
 
   _keyToPEM(key: string | Buffer): typeof key extends string | Buffer ? string | Buffer : Error {

--- a/src/node-saml/types.ts
+++ b/src/node-saml/types.ts
@@ -3,11 +3,17 @@ import type { CacheProvider } from "./inmemory-cache-provider";
 export type SignatureAlgorithm = "sha1" | "sha256" | "sha512";
 
 export interface SamlSigningOptions {
-  privateKey?: string | Buffer;
+  privateKey: string | Buffer;
   signatureAlgorithm?: SignatureAlgorithm;
   xmlSignatureTransforms?: string[];
   digestAlgorithm?: string;
 }
+
+export const isValidSamlSigningOptions = (
+  options: Partial<SamlSigningOptions>
+): options is SamlSigningOptions => {
+  return options.privateKey != null;
+};
 
 export interface AudienceRestrictionXML {
   Audience?: XMLObject[];
@@ -75,7 +81,7 @@ interface SamlScopingConfig {
  * The options required to use a SAML strategy
  * These may be provided by means of defaults specified in the constructor
  */
-export interface SamlOptions extends SamlSigningOptions, MandatorySamlOptions {
+export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlOptions {
   // Core
   callbackUrl?: string;
   path: string;

--- a/src/node-saml/utility.ts
+++ b/src/node-saml/utility.ts
@@ -1,6 +1,5 @@
-import { SignedXml } from "xml-crypto";
 import { SamlSigningOptions } from "./types";
-import * as algorithms from "./algorithms";
+import { signXml } from "./xml";
 
 export function assertRequired<T>(value: T | null | undefined, error?: string): T {
   if (value === undefined || value === null || (typeof value === "string" && value.length === 0)) {
@@ -10,37 +9,14 @@ export function assertRequired<T>(value: T | null | undefined, error?: string): 
   }
 }
 
-export function signXml(samlMessage: string, xpath: string, options: SamlSigningOptions): string {
-  const defaultTransforms = [
-    "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
-    "http://www.w3.org/2001/10/xml-exc-c14n#",
-  ];
-
-  if (!samlMessage) throw new Error("samlMessage is required");
-  if (!xpath) throw new Error("xpath is required");
-  if (!options) {
-    options = {} as SamlSigningOptions;
-  }
-
-  if (!options.privateKey) throw new Error("options.privateKey is required");
-
-  const transforms = options.xmlSignatureTransforms || defaultTransforms;
-  const sig = new SignedXml();
-  if (options.signatureAlgorithm) {
-    sig.signatureAlgorithm = algorithms.getSigningAlgorithm(options.signatureAlgorithm);
-  }
-  sig.addReference(xpath, transforms, algorithms.getDigestAlgorithm(options.digestAlgorithm));
-  sig.signingKey = options.privateKey;
-  sig.computeSignature(samlMessage, {
-    location: { reference: xpath, action: "append" },
-  });
-
-  return sig.getSignedXml();
-}
-
 export function signXmlResponse(samlMessage: string, options: SamlSigningOptions): string {
   const responseXpath =
     '//*[local-name(.)="Response" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:protocol"]';
 
-  return signXml(samlMessage, responseXpath, options);
+  return signXml(
+    samlMessage,
+    responseXpath,
+    { reference: responseXpath, action: "append" },
+    options
+  );
 }

--- a/src/node-saml/xml.ts
+++ b/src/node-saml/xml.ts
@@ -3,6 +3,7 @@ import * as xmlCrypto from "xml-crypto";
 import * as xmlenc from "xml-encryption";
 import * as xmldom from "xmldom";
 import * as xml2js from "xml2js";
+import * as xmlbuilder from "xmlbuilder";
 
 type SelectedValue = string | number | boolean | Node;
 
@@ -120,4 +121,9 @@ export const buildXml2JsObject = (rootName: string, xml: any): string => {
     headless: true,
   };
   return new xml2js.Builder(builderOpts).buildObject(xml);
+};
+
+export const buildXmlBuilderObject = (xml: Record<string, any>, pretty: boolean): string => {
+  const options = pretty ? { pretty: true, indent: "  ", newline: "\n" } : {};
+  return xmlbuilder.create(xml).end(options);
 };

--- a/src/node-saml/xml.ts
+++ b/src/node-saml/xml.ts
@@ -1,0 +1,40 @@
+import * as xmlCrypto from "xml-crypto";
+
+type SelectedValue = string | number | boolean | Node;
+
+const selectXPath = <T extends SelectedValue>(
+  guard: (values: SelectedValue[]) => values is T[],
+  node: Node,
+  xpath: string
+): T[] => {
+  const result = xmlCrypto.xpath(node, xpath);
+  if (!guard(result)) {
+    throw new Error("invalid xpath return type");
+  }
+  return result;
+};
+
+const attributesXPathTypeGuard = (values: SelectedValue[]): values is Attr[] => {
+  return values.every((value) => {
+    if (typeof value != "object") {
+      return false;
+    }
+    return typeof value.nodeType === "number" && value.nodeType === value.ATTRIBUTE_NODE;
+  });
+};
+
+const elementsXPathTypeGuard = (values: SelectedValue[]): values is Element[] => {
+  return values.every((value) => {
+    if (typeof value != "object") {
+      return false;
+    }
+    return typeof value.nodeType === "number" && value.nodeType === value.ELEMENT_NODE;
+  });
+};
+
+export const xpath = {
+  selectAttributes: (node: Node, xpath: string): Attr[] =>
+    selectXPath(attributesXPathTypeGuard, node, xpath),
+  selectElements: (node: Node, xpath: string): Element[] =>
+    selectXPath(elementsXPathTypeGuard, node, xpath),
+};

--- a/src/node-saml/xml.ts
+++ b/src/node-saml/xml.ts
@@ -98,3 +98,7 @@ export const validateXmlSignatureForCert = (
   fullXml = normalizeNewlines(fullXml);
   return sig.checkSignature(fullXml);
 };
+
+export const parseDomFromString = (xml: string): Document => {
+  return new xmldom.DOMParser().parseFromString(xml);
+};

--- a/src/node-saml/xml.ts
+++ b/src/node-saml/xml.ts
@@ -59,7 +59,7 @@ const normalizeNewlines = (xml: string): string => {
 const normalizeXml = (xml: string): string => {
   // we can use this utility to parse and re-stringify XML
   // `DOMParser` will take care of normalization tasks, like replacing XML-encoded carriage returns with actual carriage returns
-  return new xmldom.DOMParser({}).parseFromString(xml).toString();
+  return parseDomFromString(xml).toString();
 };
 
 /**

--- a/src/node-saml/xml.ts
+++ b/src/node-saml/xml.ts
@@ -2,6 +2,7 @@ import * as util from "util";
 import * as xmlCrypto from "xml-crypto";
 import * as xmlenc from "xml-encryption";
 import * as xmldom from "xmldom";
+import * as xml2js from "xml2js";
 
 type SelectedValue = string | number | boolean | Node;
 
@@ -101,4 +102,22 @@ export const validateXmlSignatureForCert = (
 
 export const parseDomFromString = (xml: string): Document => {
   return new xmldom.DOMParser().parseFromString(xml);
+};
+
+export const parseXml2JsFromString = async (xml: string | Buffer): Promise<any> => {
+  const parserConfig = {
+    explicitRoot: true,
+    explicitCharkey: true,
+    tagNameProcessors: [xml2js.processors.stripPrefix],
+  };
+  const parser = new xml2js.Parser(parserConfig);
+  return parser.parseStringPromise(xml);
+};
+
+export const buildXml2JsObject = (rootName: string, xml: any): string => {
+  const builderOpts = {
+    rootName,
+    headless: true,
+  };
+  return new xml2js.Builder(builderOpts).buildObject(xml);
 };

--- a/src/passport-saml/types.ts
+++ b/src/passport-saml/types.ts
@@ -67,3 +67,9 @@ interface BaseMultiSamlConfig {
 }
 
 export type MultiSamlConfig = Partial<SamlConfig> & StrategyOptions & BaseMultiSamlConfig;
+
+export class ErrorWithXmlStatus extends Error {
+  constructor(message: string, public readonly xmlStatus: string) {
+    super(message);
+  }
+}

--- a/test/node-saml/saml-post-signing-tests.spec.ts
+++ b/test/node-saml/saml-post-signing-tests.spec.ts
@@ -1,28 +1,129 @@
 import * as fs from "fs";
-import * as should from "should";
 import { signSamlPost, signAuthnRequestPost } from "../../src/node-saml/saml-post-signing";
 import { SamlSigningOptions } from "../../src/node-saml/types";
+import { parseXml2JsFromString } from "../../src/node-saml/xml";
 
 const signingKey = fs.readFileSync(__dirname + "/../static/key.pem");
 
 describe("SAML POST Signing", function () {
-  it("should sign a simple saml request", function () {
+  it("should sign a simple saml request", async function () {
     const xml =
       '<SAMLRequest><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://example.com</saml2:Issuer></SAMLRequest>';
     const result = signSamlPost(xml, "/SAMLRequest", { privateKey: signingKey });
-    result.should.match(/<DigestValue>[A-Za-z0-9/+=]+<\/DigestValue>/);
-    result.should.match(/<SignatureValue>[A-Za-z0-9/+=]+<\/SignatureValue>/);
+    const doc = await parseXml2JsFromString(result);
+    doc.should.be.deepEqual({
+      SAMLRequest: {
+        $: { Id: "_0" },
+        Issuer: [
+          {
+            _: "http://example.com",
+            $: { "xmlns:saml2": "urn:oasis:names:tc:SAML:2.0:assertion" },
+          },
+        ],
+        Signature: [
+          {
+            $: { xmlns: "http://www.w3.org/2000/09/xmldsig#" },
+            SignedInfo: [
+              {
+                CanonicalizationMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                ],
+                SignatureMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1" } },
+                ],
+                Reference: [
+                  {
+                    $: { URI: "#_0" },
+                    Transforms: [
+                      {
+                        Transform: [
+                          {
+                            $: {
+                              Algorithm: "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+                            },
+                          },
+                          { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                        ],
+                      },
+                    ],
+                    DigestMethod: [{ $: { Algorithm: "http://www.w3.org/2000/09/xmldsig#sha1" } }],
+                    DigestValue: [{ _: "1yis05FW/NgGxi12sn/bW3GP9co=" }],
+                  },
+                ],
+              },
+            ],
+            SignatureValue: [
+              {
+                _:
+                  "Oa5ST39rynnUH6XN4tnjoK2luRlKGOq4VHPAKqSgEjzEymTFQRhMwqwQTuFI+AwHSn0qd4wc7GGLIHn0BmUsk/CBZ51nvgjiyTQo+Gkc2/24QlCAwpOM35hgOEaMMvJXgzkFwxvnV/3TGA2J+jrrcQ0q2l6nSuDe27JnCCzbo1vFiHIuWG91pZnS0ZQKnJ593jG5ozo2m2a7l/KvCXIWCGs91KR43IKgmQmOIkVk4i170Ep2trlyj5651LFlT4LShDkkrf4tvWAmeC7rZgf97j58m9vTYXY7zZt5URIvmlE9SZH6NmUdrryZjfZin4Xf7FqpfK/sLzVfBCSLvCse8A==",
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 
-  it("should place the Signature element after the Issuer element", function () {
+  it("should place the Signature element after the Issuer element", async function () {
     const xml =
       '<SAMLRequest><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://example.com</saml2:Issuer><SomeOtherElement /></SAMLRequest>';
     const result = signSamlPost(xml, "/SAMLRequest", { privateKey: signingKey });
-    result.should.match(/<\/saml2:Issuer><Signature/);
-    result.should.match(/<\/Signature><SomeOtherElement/);
+    const doc = await parseXml2JsFromString(result);
+    doc.should.be.deepEqual({
+      SAMLRequest: {
+        $: { Id: "_0" },
+        Issuer: [
+          {
+            _: "http://example.com",
+            $: { "xmlns:saml2": "urn:oasis:names:tc:SAML:2.0:assertion" },
+          },
+        ],
+        Signature: [
+          {
+            $: { xmlns: "http://www.w3.org/2000/09/xmldsig#" },
+            SignedInfo: [
+              {
+                CanonicalizationMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                ],
+                SignatureMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1" } },
+                ],
+                Reference: [
+                  {
+                    $: { URI: "#_0" },
+                    Transforms: [
+                      {
+                        Transform: [
+                          {
+                            $: {
+                              Algorithm: "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+                            },
+                          },
+                          { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                        ],
+                      },
+                    ],
+                    DigestMethod: [{ $: { Algorithm: "http://www.w3.org/2000/09/xmldsig#sha1" } }],
+                    DigestValue: [{ _: "5z/cj0WrzI7UGvPSu543FzezwE4=" }],
+                  },
+                ],
+              },
+            ],
+            SignatureValue: [
+              {
+                _:
+                  "ggJj62O7r2KwAFyiRtQmWOGu2q1MtLFNcGGCYaeKi5/lmSwhjOqgrLLQlZnQWRIoxhkKw0OLgtT9dIeZC3+TMZtolLQ9OM0pQARz8svJuYQUd4ti71hoIRTRzgzEXbOvpyDoqXaJMeZeveidAg/DHIIATpCUwqy1soUPxiHXdweXJ8BYrNoWjFBKLULbBNmTlYEdeQqYOE3TcCuvCDYOdbQlTKRPJlC5eVz+SIRb8q6c9sHTzmFuiquFezQsroY3MEvHjO5jPQ1L3L1drVwWBeF8TNoNsHcJ8aMMMJqHzjiSDeAJZnq6G3VOisZrJVcSJWipAd383EyuhDy3Zo5PJw==",
+              },
+            ],
+          },
+        ],
+        SomeOtherElement: [""],
+      },
+    });
   });
 
-  it("should sign and digest with SHA256 when specified", function () {
+  it("should sign and digest with SHA256 when specified", async function () {
     const xml =
       '<SAMLRequest><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://example.com</saml2:Issuer></SAMLRequest>';
     const options: SamlSigningOptions = {
@@ -31,19 +132,61 @@ describe("SAML POST Signing", function () {
       privateKey: signingKey,
     };
     const result = signSamlPost(xml, "/SAMLRequest", options);
-    result.should.match(
-      /<SignatureMethod Algorithm="http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256"/
-    );
-    result.should.match(/<Transform Algorithm="http:\/\/www.w3.org\/2001\/10\/xml-exc-c14n#"\/>/);
-    result.should.match(
-      /<Transform Algorithm="http:\/\/www.w3.org\/2000\/09\/xmldsig#enveloped-signature"\/>/
-    );
-    result.should.match(
-      /<DigestMethod Algorithm="http:\/\/www.w3.org\/2001\/04\/xmlenc#sha256"\/>/
-    );
+    const doc = await parseXml2JsFromString(result);
+    doc.should.be.deepEqual({
+      SAMLRequest: {
+        $: { Id: "_0" },
+        Issuer: [
+          {
+            _: "http://example.com",
+            $: { "xmlns:saml2": "urn:oasis:names:tc:SAML:2.0:assertion" },
+          },
+        ],
+        Signature: [
+          {
+            $: { xmlns: "http://www.w3.org/2000/09/xmldsig#" },
+            SignedInfo: [
+              {
+                CanonicalizationMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                ],
+                SignatureMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" } },
+                ],
+                Reference: [
+                  {
+                    $: { URI: "#_0" },
+                    Transforms: [
+                      {
+                        Transform: [
+                          {
+                            $: {
+                              Algorithm: "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+                            },
+                          },
+                          { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                        ],
+                      },
+                    ],
+                    DigestMethod: [{ $: { Algorithm: "http://www.w3.org/2001/04/xmlenc#sha256" } }],
+                    DigestValue: [{ _: "DeVk/na+V3reUnB3kJPBXoeA12QBCaPNSr/J/1+g8X0=" }],
+                  },
+                ],
+              },
+            ],
+            SignatureValue: [
+              {
+                _:
+                  "N1vamg3kKL4lvk+i/ZPltfZRIvFPO4J+CpNslFCKcuOpVTtgxhbvaHEnmU1gTpfEmFHw2js8isKWbEWepsP+aOfQMFDTnlZM2X7HtuB6uKntpS6bOUnG4mx+P2stbRyhLzJIsDwHTvzZM5+L63O551afjZxYCJBwD2bsvUk1A/1N6dG9+AB6QP/x/Fl6OjZE9J/kQWVZbRyty48p3sIBkO1L0rVk7ekHj5f83JGRtyKt9nlK7ke8dX+BItPQ/CU353RRumQ6rSkv+MZVzqfGWcg6wIc4x5+euS9zA80eBrYOvIU9vjzK8Bd+Lv9ltAAtISMRrVCVWW0XgnKJ4fzZGg==",
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 
-  it("should sign and digest with SHA256 when specified and using privateKey", function () {
+  it("should sign and digest with SHA256 when specified and using privateKey", async function () {
     const xml =
       '<SAMLRequest><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://example.com</saml2:Issuer></SAMLRequest>';
     const options: SamlSigningOptions = {
@@ -52,23 +195,115 @@ describe("SAML POST Signing", function () {
       privateKey: signingKey,
     };
     const result = signSamlPost(xml, "/SAMLRequest", options);
-    result.should.match(
-      /<SignatureMethod Algorithm="http:\/\/www.w3.org\/2001\/04\/xmldsig-more#rsa-sha256"/
-    );
-    result.should.match(/<Transform Algorithm="http:\/\/www.w3.org\/2001\/10\/xml-exc-c14n#"\/>/);
-    result.should.match(
-      /<Transform Algorithm="http:\/\/www.w3.org\/2000\/09\/xmldsig#enveloped-signature"\/>/
-    );
-    result.should.match(
-      /<DigestMethod Algorithm="http:\/\/www.w3.org\/2001\/04\/xmlenc#sha256"\/>/
-    );
+    const doc = await parseXml2JsFromString(result);
+    doc.should.be.deepEqual({
+      SAMLRequest: {
+        $: { Id: "_0" },
+        Issuer: [
+          {
+            _: "http://example.com",
+            $: { "xmlns:saml2": "urn:oasis:names:tc:SAML:2.0:assertion" },
+          },
+        ],
+        Signature: [
+          {
+            $: { xmlns: "http://www.w3.org/2000/09/xmldsig#" },
+            SignedInfo: [
+              {
+                CanonicalizationMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                ],
+                SignatureMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" } },
+                ],
+                Reference: [
+                  {
+                    $: { URI: "#_0" },
+                    Transforms: [
+                      {
+                        Transform: [
+                          {
+                            $: {
+                              Algorithm: "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+                            },
+                          },
+                          { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                        ],
+                      },
+                    ],
+                    DigestMethod: [{ $: { Algorithm: "http://www.w3.org/2001/04/xmlenc#sha256" } }],
+                    DigestValue: [{ _: "DeVk/na+V3reUnB3kJPBXoeA12QBCaPNSr/J/1+g8X0=" }],
+                  },
+                ],
+              },
+            ],
+            SignatureValue: [
+              {
+                _:
+                  "N1vamg3kKL4lvk+i/ZPltfZRIvFPO4J+CpNslFCKcuOpVTtgxhbvaHEnmU1gTpfEmFHw2js8isKWbEWepsP+aOfQMFDTnlZM2X7HtuB6uKntpS6bOUnG4mx+P2stbRyhLzJIsDwHTvzZM5+L63O551afjZxYCJBwD2bsvUk1A/1N6dG9+AB6QP/x/Fl6OjZE9J/kQWVZbRyty48p3sIBkO1L0rVk7ekHj5f83JGRtyKt9nlK7ke8dX+BItPQ/CU353RRumQ6rSkv+MZVzqfGWcg6wIc4x5+euS9zA80eBrYOvIU9vjzK8Bd+Lv9ltAAtISMRrVCVWW0XgnKJ4fzZGg==",
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 
-  it("should sign an AuthnRequest", function () {
+  it("should sign an AuthnRequest", async function () {
     const xml =
       '<AuthnRequest xmlns="urn:oasis:names:tc:SAML:2.0:protocol"><saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">http://example.com</saml2:Issuer></AuthnRequest>';
     const result = signAuthnRequestPost(xml, { privateKey: signingKey });
-    result.should.match(/<DigestValue>[A-Za-z0-9/+=]+<\/DigestValue>/);
-    result.should.match(/<SignatureValue>[A-Za-z0-9/+=]+<\/SignatureValue>/);
+    const doc = await parseXml2JsFromString(result);
+    doc.should.be.deepEqual({
+      AuthnRequest: {
+        $: { xmlns: "urn:oasis:names:tc:SAML:2.0:protocol", Id: "_0" },
+        Issuer: [
+          {
+            _: "http://example.com",
+            $: { "xmlns:saml2": "urn:oasis:names:tc:SAML:2.0:assertion" },
+          },
+        ],
+        Signature: [
+          {
+            $: { xmlns: "http://www.w3.org/2000/09/xmldsig#" },
+            SignedInfo: [
+              {
+                CanonicalizationMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                ],
+                SignatureMethod: [
+                  { $: { Algorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1" } },
+                ],
+                Reference: [
+                  {
+                    $: { URI: "#_0" },
+                    Transforms: [
+                      {
+                        Transform: [
+                          {
+                            $: {
+                              Algorithm: "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+                            },
+                          },
+                          { $: { Algorithm: "http://www.w3.org/2001/10/xml-exc-c14n#" } },
+                        ],
+                      },
+                    ],
+                    DigestMethod: [{ $: { Algorithm: "http://www.w3.org/2000/09/xmldsig#sha1" } }],
+                    DigestValue: [{ _: "wHDDyV7rEQ/AQLYeLgsEUXX+Zxw=" }],
+                  },
+                ],
+              },
+            ],
+            SignatureValue: [
+              {
+                _:
+                  "t6Vg5DrOQiwfVv1IBzhPXMwoRGdNY1lIKbvcZOXr9EeFEEaI8I8qPs9Ibl+Hj3eCC0aDVLg/Uhg9/NCygfYuQuJjFdji0/rEFve/DEgGDscCS42+0J5fM55wNyVLglly9D+hJdZChmHg5IQltFcvOsNHYxbUiPywbOSLSHHFqOfdL4bqYNO/nwhhHMRuA6VQGRSC8EGJkjF9kwuFVjF7XvXyV2aTRJgZYmUB3fzIlokUfBNg2PpvexLipOb1K14ZV0nORewOCPjulJWnd+WSJkHBY1jA/OGiJNCeokOw7XTOLrAZ9+d4/JJ7T3XthWwHrfP3gEljoNTUdQV/gBNNqA==",
+              },
+            ],
+          },
+        ],
+      },
+    });
   });
 });


### PR DESCRIPTION
# Description

This PR moves most of the XML but non SAML logic to a dedicated file. It tries to improve some types when it's possible. 
The idea is:
1- to isolate dependencies, which I think is always a good idea. Especially when those dependencies are non in TS, this allows to group the "typing danger  zone"
2- shrink saml.ts by moving as much as possible non SAML related logic out.

This PR should not break anything and is done without updating any tests as a result.

Possible follow ups:
- Create a similar crypto-utils for everything crypto (PEM conversion, etc)
- See if xmlbuilder dependency could be dropped in favor of xml2js builder (which is built using xmlbuilder I think). This would avoid depending on 2 different version of xmlbuilder (v15 as a direct dep, v11 via xml2js)

This PR is best reviewed commit per commit.

Let me know what you think.