### PR TITLE
Resolve XML-encoded carriage returns during signature validation (2.x)

### DIFF
--- a/src/passport-saml/saml.ts
+++ b/src/passport-saml/saml.ts
@@ -730,6 +730,8 @@ class SAML {
     if (totalReferencedNodes.length > 1) {
       return false;
     }
+    // normalize XML to replace XML-encoded carriage returns with actual carriage returns
+    fullXml = this.normalizeXml(fullXml);
     fullXml = this.normalizeNewlines(fullXml);
     return sig.checkSignature(fullXml);
   }
@@ -1417,6 +1419,12 @@ class SAML {
     // we are considered the XML processor and are responsible for newline normalization
     // https://github.com/node-saml/passport-saml/issues/431#issuecomment-718132752
     return xml.replace(/\r\n?/g, "\n");
+  }
+
+  normalizeXml(xml: string): string {
+    // we can use this utility to parse and re-stringify XML
+    // `DOMParser` will take care of normalization tasks, like replacing XML-encoded carriage returns with actual carriage returns
+    return new xmldom.DOMParser({}).parseFromString(xml).toString();
   }
 }
 

--- a/test/test-signatures.js
+++ b/test/test-signatures.js
@@ -100,4 +100,27 @@ describe('Signatures', function() {
 
   });
 
+  describe("Signature on saml:Response with XML-encoded carriage returns", () => {
+    const samlResponseXml = fs
+      .readFileSync(
+        __dirname + "/static/signatures/valid/response.root-unsigned.assertion-signed.xml"
+      )
+      .toString();
+    const makeBody = (str) => ({ SAMLResponse: Buffer.from(str).toString("base64") });
+
+    const insertChars = (str, where, chars) =>
+      str.replace(new RegExp(`(<ds:${where}>)(.{10})(.{10})`), `$1$2${chars}$3`);
+
+    it("SignatureValue with &#13;", async () => {
+      const body = makeBody(insertChars(samlResponseXml, "SignatureValue", "&#13;"));
+      await testOneResponseBody(body, false, 2);
+    });
+
+    it("SignatureValue with &#xd;", async () => {
+      const body = makeBody(insertChars(samlResponseXml, "SignatureValue", "&#xd;"));
+      await testOneResponseBody(body, false, 2);
+    });
+
+  });
+
 });


### PR DESCRIPTION
# Description

This is a 2.x backport of https://github.com/node-saml/passport-saml/pull/576.

Resolves https://github.com/node-saml/passport-saml/issues/575. See that issue for background.

This adds XML normalization to validateSignatureForCert before sending it to xml-crypto. It uses DOMParser for normalization tasks such as replacement of XML-encoded entities (&#13;) with their actual representations (carriage return).

# Checklist:

- Issue Addressed: [X]
- Link to SAML spec: [ ]
- Tests included? [X]
- Documentation updated? N/A