### PR TITLE
Fix: Conflicting profile properties between profile and attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ yarn-error.log
 .DS_Store 
 .eslintcache
 .dir-locals.el
+
+## Local VS code settings and debug profiles
+.vscode

--- a/src/node-saml/saml.ts
+++ b/src/node-saml/saml.ts
@@ -1170,13 +1170,21 @@ class SAML {
       };
 
       if (attributes) {
+        const profileAttributes: Record<string, unknown> = {};
+
         attributes.forEach((attribute) => {
           if (!Object.prototype.hasOwnProperty.call(attribute, "AttributeValue")) {
             // if attributes has no AttributeValue child, continue
             return;
           }
+
           const name = attribute.$.Name;
-          const value = attribute.AttributeValue;
+          const value =
+            attribute.AttributeValue.length === 1
+              ? attrValueMapper(attribute.AttributeValue[0])
+              : attribute.AttributeValue.map(attrValueMapper);
+
+          profileAttributes[name] = value;
 
           // If any property is already present in profile and is also present
           // in attributes, then skip the one from attributes. Handle this
@@ -1185,12 +1193,10 @@ class SAML {
             return;
           }
 
-          if (value.length === 1) {
-            profile[name] = attrValueMapper(value[0]);
-          } else {
-            profile[name] = value.map(attrValueMapper);
-          }
+          profile[name] = value;
         });
+
+        profile.attributes = profileAttributes;
       }
     }
 

--- a/src/node-saml/saml.ts
+++ b/src/node-saml/saml.ts
@@ -1175,11 +1175,20 @@ class SAML {
             // if attributes has no AttributeValue child, continue
             return;
           }
+          const name = attribute.$.Name;
           const value = attribute.AttributeValue;
+
+          // If any property is already present in profile and is also present
+          // in attributes, then skip the one from attributes. Handle this
+          // conflict gracefully without returning any error
+          if (Object.prototype.hasOwnProperty.call(profile, name)) {
+            return;
+          }
+
           if (value.length === 1) {
-            profile[attribute.$.Name] = attrValueMapper(value[0]);
+            profile[name] = attrValueMapper(value[0]);
           } else {
-            profile[attribute.$.Name] = value.map(attrValueMapper);
+            profile[name] = value.map(attrValueMapper);
           }
         });
       }

--- a/test/node-saml/tests.spec.ts
+++ b/test/node-saml/tests.spec.ts
@@ -1992,11 +1992,6 @@ describe("node-saml /", function () {
         '<saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0">' +
         "<saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>" +
         "<saml2:AttributeStatement>" +
-        '<saml2:Attribute Name="attributeName" ' +
-        'NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified">' +
-        '<saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" ' +
-        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
-        'xsi:type="xs:string"/>' +
         "</saml2:Attribute>" +
         '<saml2:Attribute Name="issuer" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">' +
         '<saml2:AttributeValue xsi:type="xs:string">test</saml2:AttributeValue>' +
@@ -2010,6 +2005,7 @@ describe("node-saml /", function () {
       });
 
       should(profile!.issuer).not.be.equal("test");
+      should(profile!.attributes).containEql({ issuer: "test" });
     });
   });
 


### PR DESCRIPTION
# Description
https://github.com/node-saml/passport-saml/blob/f1a436fa243080f8cfcf06fd0f40ce3af396c8b6/src/passport-saml/saml.ts#L1319
It is currently possible to override some default properties of the `profile` object in `processValidlySignedAssertionAsync` method.
This can be done if any property like `Issuer` is also present in the attribute mapping. The expected behavior here should be that the properties (`Issuer`, `inResponseTo`, `sessionIndex`, `nameID`, `nameIDFormat`, `nameQualifier`, `spNameQualifier`) will probably already be present in the profile, and in that case they shouldn't be overridden by the same named attribute in attribute mapping.

This issue can be handled gracefully by simply skipping the value from attribute mapping or an error can be thrown. This PR handles the issue gracefully. 

# Checklist:

- Issue Addressed: [#543]
- Link to SAML spec: [ ]
- Tests included? Yes
- Documentation updated? Not Required