### PR TITLE
Fix validateInResponseTo null check

### DIFF
--- a/src/node-saml/saml.ts
+++ b/src/node-saml/saml.ts
@@ -871,7 +871,7 @@ class SAML {
       }
     } catch (err) {
       debug("validatePostResponse resulted in an error: %s", err);
-      if (this.options.validateInResponseTo != null) {
+      if (this.options.validateInResponseTo) {
         await this.cacheProvider.removeAsync(inResponseTo!);
       }
       throw err;


### PR DESCRIPTION
# Description

When validateInResponseTo isn't set to `true`, we end up setting it to `false` here: https://github.com/node-saml/passport-saml/blob/13c7216644ba055217fc97b41df63301be982137/src/node-saml/saml.ts#L155

This value was then checked if it's not `null` here, which is always true. The intention was likely to have this check check if the value was true, like everywhere else this value is used. This changes the gate to just check if the value is true.

This is a small enough change so I won't default to writing a test for this edge behavior - an extra delete call to the cache provider isn't a big deal, but I found this when debugging our custom cache provider.

# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]
