### PR TITLE
Feature: add facility in config to add `<Extensions>` element in SAML request

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ type Profile = {
 - `additionalLogoutParams`: dictionary of additional query params to add to 'logout' requests
 - `logoutCallbackUrl`: The value with which to populate the `Location` attribute in the `SingleLogoutService` elements in the generated service provider metadata.
 
+- **Extensions**
 - `extensions`: Optional, The extension provides a more flexible structure for expressing which combination of Attributes are requested by service providers in comparison to the existing mechanisms, [More about extensions](https://www.oasis-open.org/committees/download.php/55790/Connectis%20_protocol_extension_draft.pdf). It accept fully customize [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type. There are many possible value for `extensions` element. You can use [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) to request attributes/data as per your need in SAML Request.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ Passport-SAML has been tested to work with Onelogin, Okta, Shibboleth, [SimpleSA
 
     $ npm install passport-saml
 
-/
-
 ## Usage
 
 The examples utilize the [Feide OpenIdp identity provider](https://openidp.feide.no/). You need an account there to log in with this. You also need to [register your site](https://openidp.feide.no/simplesaml/module.php/metaedit/index.php) as a service provider.
@@ -175,6 +173,24 @@ type Profile = {
 - `logoutUrl`: base address to call with logout requests (default: `entryPoint`)
 - `additionalLogoutParams`: dictionary of additional query params to add to 'logout' requests
 - `logoutCallbackUrl`: The value with which to populate the `Location` attribute in the `SingleLogoutService` elements in the generated service provider metadata.
+
+- `extensions`: Optional, The extension provides a more flexible structure for expressing which combination of Attributes are requested by service providers in comparison to the existing mechanisms, [More about extensions](https://www.oasis-open.org/committees/download.php/55790/Connectis%20_protocol_extension_draft.pdf). It accept fully customize [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type. There are many possible value for `extensions` element. You can use [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) to request attributes/data as per your need in SAML Request.
+
+```javascript
+// Example
+extensions: {
+  "md:RequestedAttribute": {
+    "@isRequired": "true",
+    "@Name": "Lastname",
+  },
+  vetuma: {
+    "@xmlns": "urn:vetuma:SAML:2.0:extensions",
+    LG: {
+      "#text": "sv",
+    },
+  },
+},
+```
 
 ### Provide the authentication callback
 

--- a/src/node-saml/saml.ts
+++ b/src/node-saml/saml.ts
@@ -355,6 +355,10 @@ class SAML {
       request["samlp:AuthnRequest"]["samlp:Scoping"] = scoping;
     }
 
+    if (this.options.extensions != null) {
+      request["samlp:AuthnRequest"]["samlp:Extensions"] = this.options.extensions;
+    }
+
     let stringRequest = buildXmlBuilderObject(request, false);
     // TODO: maybe we should always sign here
     if (isHttpPostBinding && isValidSamlSigningOptions(this.options)) {

--- a/src/node-saml/types.ts
+++ b/src/node-saml/types.ts
@@ -123,4 +123,5 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
 
   // extras
   disableRequestAcsUrl: boolean;
+  extensions?: any;
 }

--- a/test/passport-saml/capturedSamlRequests.spec.ts
+++ b/test/passport-saml/capturedSamlRequests.spec.ts
@@ -859,6 +859,73 @@ const capturedSamlRequestChecks: SamlCheck[] = [
       },
     },
   },
+  {
+    name: "Config with Extensions",
+    config: {
+      cert: FAKE_CERT,
+      extensions: {
+        "md:RequestedAttribute": {
+          "@isRequired": "true",
+          "@Name": "Lastname",
+        },
+        vetuma: {
+          "@xmlns": "urn:vetuma:SAML:2.0:extensions",
+          LG: {
+            "#text": "sv",
+          },
+        },
+      },
+    },
+    result: {
+      "samlp:AuthnRequest": {
+        $: {
+          "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+          Version: "2.0",
+          ProtocolBinding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+          AssertionConsumerServiceURL: "http://localhost:3033/login",
+          Destination: "https://wwwexampleIdp.com/saml",
+        },
+        "saml:Issuer": [
+          { _: "onelogin_saml", $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" } },
+        ],
+        "samlp:NameIDPolicy": [
+          {
+            $: {
+              "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol",
+              Format: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+              AllowCreate: "true",
+            },
+          },
+        ],
+        "samlp:RequestedAuthnContext": [
+          {
+            $: { "xmlns:samlp": "urn:oasis:names:tc:SAML:2.0:protocol", Comparison: "exact" },
+            "saml:AuthnContextClassRef": [
+              {
+                _: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+                $: { "xmlns:saml": "urn:oasis:names:tc:SAML:2.0:assertion" },
+              },
+            ],
+          },
+        ],
+        "samlp:Extensions": [
+          {
+            "md:RequestedAttribute": [
+              {
+                $: { isRequired: "true", Name: "Lastname" },
+              },
+            ],
+            vetuma: [
+              {
+                $: { xmlns: "urn:vetuma:SAML:2.0:extensions" },
+                LG: ["sv"],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
 ];
 
 export const logoutChecks: CapturedCheck[] = [


### PR DESCRIPTION
## Issue
close https://github.com/node-saml/passport-saml/issues/602

## Description

Add support in `passport-saml` where it will allow admin to configure fully customise `<Extensions>` element and add it into SAML Request.

`<Extensions>` element are use to request custom attributes and setting. Its structure and values different as as IDP configurations and requests.

## Use cases
1.  Use `<Extensions>` element to request attributes/data. [More details, oasis-open.org SAML V2.0 Protocol Extension for Requesting Attributes per Request](http://docs.oasis-open.org/security/saml-protoc-req-attr-req/v1.0/saml-protoc-req-attr-req-v1.0.html)
2. Use `<Extensions>` element to request with some custom config. For Example: In [suomi.fi](https://palveluhallinta.suomi.fi/en/tuki/artikkelit/59116c3014bbb10001966f70) idp, its allows SP to request with custom language code by passing it `<Extensions>` element. [More details](https://palveluhallinta.suomi.fi/en/tuki/artikkelit/59116c3014bbb10001966f70)

## Changes

- `src/node-saml/types.ts` : added `extensions` optional variable. The type is `any` and it accept [XMLBuilder](https://www.npmjs.com/package/xmlbuilder) type values because as per use cases and IDPs', there are many cases and each use cases have different request format/data. Please let me know what is your view on this.
-  `src/node-saml/saml.ts`: added it in `request`. As it has already XMLBuilder values so no need to do any processing.
-  Test cases added
-  Docs updated 
-  No Breaking Changes

# Checklist:

- [x] Issue Addressed
- [x] Link to SAML spec
- [x] Tests included
- [x] Documentation updated
