### PR TITLE
restore BC for authnContext config

### DIFF
--- a/src/node-saml/types.ts
+++ b/src/node-saml/types.ts
@@ -98,7 +98,7 @@ export interface SamlOptions extends Partial<SamlSigningOptions>, MandatorySamlO
   acceptedClockSkewMs: number;
   attributeConsumingServiceIndex?: string;
   disableRequestedAuthnContext: boolean;
-  authnContext: string[];
+  authnContext: string | string[];
   forceAuthn: boolean;
   skipRequestCompression: boolean;
   authnRequestBinding?: string;


### PR DESCRIPTION
As per the documentation this config allows to be a string or an array of strings

