### PR TITLE
Fix main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "Chris Barth",
     "Andrii Kostenko"
   ],
-  "main": "./lib/passport-saml",
+  "main": "./lib",
   "files": [
     "lib",
     "README.md",


### PR DESCRIPTION
The main path in package.json needs to be updated for the recent changes to package structure. (`./lib/passport-saml` no longer exists, now the root is in `./lib`)
