### PR TITLE
Add support for multiple signing certs in metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ As a convenience, the strategy object exposes a `generateServiceProviderMetadata
 
 The `decryptionCert` argument should be a public certificate matching the `decryptionPvk` and is required if the strategy is configured with a `decryptionPvk`.
 
-The `signingCert` argument should be a public certificate matching the `privateKey` and is required if the strategy is configured with a `privateKey`.
+The `signingCert` argument should be a public certificate matching the `privateKey` and is required if the strategy is configured with a `privateKey`. An array of certificates can be provided to support certificate rotation. When supplying an array of certificates, the first entry in the array should match the current `privateKey`. Additional entries in the array can be used to publish upcoming certificates to IdPs before changing the `privateKey`.
 
 The `generateServiceProviderMetadata` method is also available on the `MultiSamlStrategy`, but needs an extra request and a callback argument (`generateServiceProviderMetadata( req, decryptionCert, signingCert, next )`), which are passed to the `getSamlOptions` to retrieve the correct configuration.
 

--- a/src/multiSamlStrategy.ts
+++ b/src/multiSamlStrategy.ts
@@ -71,7 +71,7 @@ export class MultiSamlStrategy extends AbstractStrategy {
   generateServiceProviderMetadata(
     req: Request,
     decryptionCert: string | null,
-    signingCert: string | null,
+    signingCert: string | string[] | null,
     callback: (err: Error | null, metadata?: string) => void
   ): void {
     if (typeof callback !== "function") {

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -224,7 +224,7 @@ export abstract class AbstractStrategy extends PassportStrategy {
 
   protected _generateServiceProviderMetadata(
     decryptionCert: string | null,
-    signingCert?: string | null
+    signingCert?: string | string[] | null
   ): string {
     if (this._saml == null) {
       throw new Error("Can't generate service provider metadata without a SAML provider defined.");
@@ -247,7 +247,7 @@ export class Strategy extends AbstractStrategy {
 
   generateServiceProviderMetadata(
     decryptionCert: string | null,
-    signingCert?: string | null
+    signingCert?: string | string[] | null
   ): string {
     return this._generateServiceProviderMetadata(decryptionCert, signingCert);
   }


### PR DESCRIPTION
# Description

This PR adds the ability to pass an array of signing certs when generating SAML metadata.  This makes it possible to do signing certificate rotation with IdPs that poll for metadata updates.

See the PR in [node-saml](https://github.com/node-saml/node-saml/pull/23 ) for more details.

# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [n/a]
- Tests included? [n/a]
- Documentation updated? [x]
