### PR TITLE
Update xml-encryption to get rid of vulnerable node-forge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,15 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "3.1.2",
+      "name": "passport-saml",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.5",
         "debug": "^4.3.2",
         "passport-strategy": "^1.0.0",
         "xml-crypto": "^2.1.3",
-        "xml-encryption": "^1.3.0",
+        "xml-encryption": "^2.0.0",
         "xml2js": "^0.4.23",
         "xmlbuilder": "^15.1.1"
       },
@@ -4405,14 +4406,6 @@
       "dependencies": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/nopt": {
@@ -11897,17 +11890,16 @@
       }
     },
     "node_modules/xml-encryption": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.3.0.tgz",
-      "integrity": "sha512-3P8C4egMMxSR1BmsRM+fG16a3WzOuUEQKS2U4c3AZ5v7OseIfdUeVkD8dwxIhuLryFZSRWUL5OP6oqkgU7hguA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+      "integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
       "dependencies": {
         "@xmldom/xmldom": "^0.7.0",
         "escape-html": "^1.0.3",
-        "node-forge": "^0.10.0",
         "xpath": "0.0.32"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/xml2js": {
@@ -15668,11 +15660,6 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "nopt": {
       "version": "5.0.0",
@@ -21538,13 +21525,12 @@
       }
     },
     "xml-encryption": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.3.0.tgz",
-      "integrity": "sha512-3P8C4egMMxSR1BmsRM+fG16a3WzOuUEQKS2U4c3AZ5v7OseIfdUeVkD8dwxIhuLryFZSRWUL5OP6oqkgU7hguA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+      "integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
       "requires": {
         "@xmldom/xmldom": "^0.7.0",
         "escape-html": "^1.0.3",
-        "node-forge": "^0.10.0",
         "xpath": "0.0.32"
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "debug": "^4.3.2",
     "passport-strategy": "^1.0.0",
     "xml-crypto": "^2.1.3",
-    "xml-encryption": "^1.3.0",
+    "xml-encryption": "^2.0.0",
     "xml2js": "^0.4.23",
     "xmlbuilder": "^15.1.1"
   },


### PR DESCRIPTION
This update actually /remove/ node forge to use native nodejs crypto instead. This is nice as node-forge is a fairly large module.

The major version bump in xml-encryption is because this update remove support for node < 12 (which are already not supported by passport-saml)

This PR is on the 3.x branch.