### PR TITLE
🎨  add MultiStrategyConfig type export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { Strategy, AbstractStrategy } from "./strategy";
 import { MultiSamlStrategy } from "./multiSamlStrategy";
 
-import type { VerifiedCallback, VerifyWithRequest, VerifyWithoutRequest } from "./types";
+import type {
+  VerifiedCallback,
+  VerifyWithRequest,
+  VerifyWithoutRequest,
+  MultiStrategyConfig,
+} from "./types";
 
 export * from "node-saml";
 
@@ -12,4 +17,5 @@ export {
   VerifiedCallback,
   VerifyWithRequest,
   VerifyWithoutRequest,
+  MultiStrategyConfig,
 };


### PR DESCRIPTION
# Description
Exporting `MultiStrategyConfig` type from src index so the type is available and can be imported for segregating the code and be used like below

```
import { MultiSamlStrategy, VerifyWithRequest, MultiSamlConfig } from 'passport-saml';

const multiSamlOptions: MultiSamlConfig = {
  passReqToCallback: true, // makes req available in callback
  getSamlOptions: async (request, done) => {
    const configuration = await findProvider(request);
    return done(null, configuration);
  },
};

export const multiSamlStrategy = new MultiSamlStrategy(multiSamlOptions, login);
```

# Checklist:

- Issue Addressed: [ ]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]
