### PR TITLE
make RequestWithUser.samlLogoutRequest optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -19,7 +19,7 @@ export interface StrategyOptions {
 export type User = Record<string, unknown>;
 
 export interface RequestWithUser extends express.Request {
-  samlLogoutRequest: Profile;
+  samlLogoutRequest?: Profile;
   user: User;
 }
 


### PR DESCRIPTION
# Description

whenever I try to do `passport.use('strategyName', new SamlStrategy(...))` I get the following error:
```
Argument of type 'import("/Users/calvinhuang/scale/scaleapi3/server/node_modules/passport-saml/lib/passport-saml/strategy").Strategy' is not assignable to parameter of type 'import("/Users/calvinhuang/scale/scaleapi3/server/node_modules/@types/passport/index").Strategy'
  Types of property 'authenticate' are incompatible.
    Type '(req: RequestWithUser, options: AuthenticateOptions) => void' is not assignable to type '(this: StrategyCreated<Strategy, Strategy & StrategyCreatedStatic>, req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, options?: any) => any'.
      Types of parameters 'req' and 'req' are incompatible.
        Property 'samlLogoutRequest' is missing in type 'Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>' but required in type 'RequestWithUser'.
```
It doesn't make sense to me that samlLogoutRequest needs to be present on every authentication request, and removing this would allow it to typecheck properly.

I'm using @types/passport 1.0.7.

# Checklist:

- Issue Addressed: [x]
- Link to SAML spec: [ ]
- Tests included? [ ]
- Documentation updated? [ ]
