### PR TITLE
Have dependabot update package.json too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    # Always increase the version requirement
+    # to match the new version.
+    versioning-strategy: increase
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
When updating dependencies, have dependabot record the update in `package.json`, not just `package-lock.json`