### PR TITLE
Allow to configure optional logger function to log SAML operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Please see the [type specification](https://github.com/node-saml/node-saml/blob/
 - `authnRequestBinding`: if set to `HTTP-POST`, will request authentication from IDP via HTTP POST binding, otherwise defaults to HTTP Redirect
 - `disableRequestAcsUrl`: if truthy, SAML AuthnRequest from the service provider will not include the optional AssertionConsumerServiceURL. Default is falsy so it is automatically included.
 - `scoping`: An optional configuration which implements the functionality [explained in the SAML spec paragraph "3.4.1.2 Element \<Scoping\>"](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf). The config object is structured as following:
+- `log`: optional logger function to log SAML request and response.
 
 ```javascript
 {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface AuthorizeOptions extends AuthenticateOptions {
 export interface StrategyOptions {
   name?: string;
   passReqToCallback?: boolean;
+  log?: any;
 }
 
 export type User = Record<string, unknown>;


### PR DESCRIPTION
# Description

Extended `StrategyOptions` to define optional logger function to log SAML request/response with respect to node-saml library [issue](https://github.com/node-saml/node-saml/pull/262).

# Checklist:

- Issue Addressed: [#279]
- Link to SAML spec: [ ]
- Tests included? [No]
- Documentation updated? [Yes]
