### PR TITLE
Use secure version of node-saml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -564,20 +564,20 @@
       }
     },
     "@node-saml/node-saml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-4.0.0.tgz",
-      "integrity": "sha512-C3Vl14kZv55Vj464OWOJIEE4abdNH04SSvB+CXHCIaMSjY4QAnqvWykN/UGBSaRET/+7XK7B9v8jcMqJgvvPJw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-4.0.4.tgz",
+      "integrity": "sha512-oybUBWBYVsHGckQxzyzlpRM4E2iuW3I2Ok/J9SwlotdmjvmZxSo6Ub74D9wltG8C9daJZYI57uy+1UK4FtcGXA==",
       "requires": {
         "@types/debug": "^4.1.7",
         "@types/passport": "^1.0.11",
         "@types/xml-crypto": "^1.4.2",
         "@types/xml-encryption": "^1.2.1",
         "@types/xml2js": "^0.4.11",
-        "@xmldom/xmldom": "^0.8.3",
+        "@xmldom/xmldom": "^0.8.6",
         "debug": "^4.3.4",
-        "xml-crypto": "^3.0.0",
-        "xml-encryption": "^3.0.1",
-        "xml2js": "^0.4.23",
+        "xml-crypto": "^3.0.1",
+        "xml-encryption": "^3.0.2",
+        "xml2js": "^0.5.0",
         "xmlbuilder": "^15.1.1"
       }
     },
@@ -1347,9 +1347,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -3322,9 +3322,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http-errors": {
@@ -3998,9 +3998,9 @@
       }
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -5237,9 +5237,9 @@
           }
         },
         "http-cache-semantics": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-          "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+          "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
           "dev": true
         },
         "http-proxy-agent": {
@@ -8391,9 +8391,9 @@
       "dev": true
     },
     "vm2": {
-      "version": "3.9.11",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.11.tgz",
-      "integrity": "sha512-PFG8iJRSjvvBdisowQ7iVF580DXb1uCIiGaXgm7tynMR1uTBlv7UJlB1zdv5KJ+Tmq1f0Upnj3fayoEOPpCBKg==",
+      "version": "3.9.16",
+      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.16.tgz",
+      "integrity": "sha512-3T9LscojNTxdOyG+e8gFeyBXkMlOBYDoF6dqZbj+MPVHi9x10UfiTAJIobuchRCp3QvC+inybTbMJIUrLsig0w==",
       "dev": true,
       "requires": {
         "acorn": "^8.7.0",
@@ -8605,11 +8605,11 @@
       "dev": true
     },
     "xml-crypto": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.0.0.tgz",
-      "integrity": "sha512-vdmZOsWgjnFxYGY7OwCgxs+HLWzwvLgX2n0NSYWh3gudckQyNOmtJTT6ooOWEvDZSpC9qRjRs2bEXqKFi1oCHw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-3.0.1.tgz",
+      "integrity": "sha512-7XrwB3ujd95KCO6+u9fidb8ajvRJvIfGNWD0XLJoTWlBKz+tFpUzEYxsN+Il/6/gHtEs1RgRh2RH+TzhcWBZUw==",
       "requires": {
-        "@xmldom/xmldom": "^0.8.3",
+        "@xmldom/xmldom": "^0.8.5",
         "xpath": "0.0.32"
       },
       "dependencies": {
@@ -8621,11 +8621,11 @@
       }
     },
     "xml-encryption": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-3.0.1.tgz",
-      "integrity": "sha512-KhHltZXyQ43nGFuZr+UMfCa5G6Ws2uXdiLLJPBP3SRlMh6PmUJkXqMHdhYpy0wSgEkx4UKBQ59nRmZxcXL+4GA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-3.0.2.tgz",
+      "integrity": "sha512-VxYXPvsWB01/aqVLd6ZMPWZ+qaj0aIdF+cStrVJMcFj3iymwZeI0ABzB3VqMYv48DkSpRhnrXqTUkR34j+UDyg==",
       "requires": {
-        "@xmldom/xmldom": "^0.8.3",
+        "@xmldom/xmldom": "^0.8.5",
         "escape-html": "^1.0.3",
         "xpath": "0.0.32"
       },
@@ -8638,9 +8638,9 @@
       }
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "watch": "concurrently --kill-others \"npm:*-watch\""
   },
   "dependencies": {
-    "@node-saml/node-saml": "^4.0.0",
+    "@node-saml/node-saml": "^4.0.4",
     "@types/express": "^4.17.14",
     "@types/passport": "^1.0.11",
     "@types/passport-strategy": "^0.2.35",


### PR DESCRIPTION
# Description

node-saml has been updated with a patch release to address a security concern. Set the minimum allowed version of node-saml to make sure we get that security patch.