### PR TITLE
Return unauthorized if no samlOptions is provided

### DIFF
--- a/src/multiSamlStrategy.ts
+++ b/src/multiSamlStrategy.ts
@@ -45,6 +45,10 @@ export class MultiSamlStrategy extends AbstractStrategy {
         return this.error(err);
       }
 
+      if (!samlOptions) {
+        return this.fail(401);
+      }
+
       const samlService = new SAML({ ...this._options, ...samlOptions });
       const strategy = Object.assign({}, this, { _saml: samlService });
       Object.setPrototypeOf(strategy, this);
@@ -93,8 +97,13 @@ export class MultiSamlStrategy extends AbstractStrategy {
     });
   }
 
-  // This is reduntant, but helps with testing
+  // This is redundant, but helps with testing
   error(err: Error): void {
     super.error(err);
+  }
+
+  // This is redundant, but helps with testing
+  fail(status: number): void {
+    super.fail(status);
   }
 }

--- a/test/multiSamlStrategy.spec.ts
+++ b/test/multiSamlStrategy.spec.ts
@@ -28,12 +28,16 @@ describe("MultiSamlStrategy()", function () {
   });
 
   describe("authenticate", function () {
+    let failStub: sinon.SinonStub;
+
     beforeEach(function () {
       this.superAuthenticateStub = sinon.stub(AbstractStrategy.prototype, "authenticate");
+      failStub = sinon.stub(MultiSamlStrategy.prototype, "fail");
     });
 
     afterEach(function () {
       this.superAuthenticateStub.restore();
+      failStub.restore();
     });
 
     it("calls super with request and auth options", function (done) {
@@ -65,6 +69,24 @@ describe("MultiSamlStrategy()", function () {
           try {
             fn(null, { cert: FAKE_CERT, issuer: "onesaml_login" });
             expect(strategy._passReqToCallback!).to.equal(true);
+            done();
+          } catch (err2) {
+            done(err2);
+          }
+        },
+      };
+
+      const strategy = new MultiSamlStrategy(passportOptions, noop, noop);
+      strategy.authenticate("random" as any, "random" as any);
+    });
+
+    it("getting empty saml config", function (done) {
+      const passportOptions = {
+        passReqToCallback: true,
+        getSamlOptions: function (req: express.Request, fn: StrategyOptionsCallback) {
+          try {
+            fn(null, undefined);
+            sinon.assert.calledOnce(failStub);
             done();
           } catch (err2) {
             done(err2);


### PR DESCRIPTION
If a saml config can't be found for a user in a `multiSamlStrategy` setup, it probably means that the user is not authorized to login (via saml), so return 401 in those cases. Previously, missing `samlOptions` raised an exception in node-saml where the check for `samlOptions.issuer` failed.

# Checklist:

- Issue Addressed: [-]
- Link to SAML spec: [-]
- Tests included? [x]
- Documentation updated? [-] (couldn't find any documentation for the current behavior)
