### PR TITLE
Revised AbstractStrategy for authenticate method to match PassportStrategy expectation

### DIFF
--- a/src/multiSamlStrategy.ts
+++ b/src/multiSamlStrategy.ts
@@ -39,7 +39,7 @@ export class MultiSamlStrategy extends AbstractStrategy {
     this._options = samlConfig;
   }
 
-  authenticate(req: RequestWithUser, options: AuthenticateOptions): void {
+  authenticate(req: Request, options: AuthenticateOptions): void {
     this._options.getSamlOptions(req, (err, samlOptions) => {
       if (err) {
         return this.error(err);

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -10,6 +10,7 @@ import {
   VerifyWithoutRequest,
   VerifyWithRequest,
 } from "./types";
+import { Request } from "express";
 
 export abstract class AbstractStrategy extends PassportStrategy {
   static readonly newSamlProviderOnConstruct: boolean;
@@ -56,7 +57,7 @@ export abstract class AbstractStrategy extends PassportStrategy {
     this._passReqToCallback = !!options.passReqToCallback;
   }
 
-  authenticate(req: RequestWithUser, options: AuthenticateOptions): void {
+  authenticate(req: Request, options: AuthenticateOptions): void {
     if (this._saml == null) {
       throw new Error("Can't get authenticate without a SAML provider defined.");
     }
@@ -256,7 +257,7 @@ export abstract class AbstractStrategy extends PassportStrategy {
   redirect(url: string, status?: number): void {
     super.redirect(url, status);
   }
-  success(user: any, info?: any): void {
+  success(user: unknown, info?: unknown): void {
     super.success(user, info);
   }
 }


### PR DESCRIPTION
Revised AbstractStrategy for authenticate method to match PassportStrategy expectation

# Description

The previous implementation was using the RequestWithUser internal type that contradict the base PassportStrategy authenticate given that user property SHOULD NOT be required for this process.
This causes a typings issue with the base passport which overrides the express Request interface to have a user property that is of type User | undefined;

# Checklist:

- Issue Addressed: N/A
- Link to SAML spec: N/A
- Tests included? No, fixing a typings issue with core base package
- Documentation updated? Not needed, seamless change
