### PR TITLE
Remove unused `AuthorizeOptions` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,6 @@ export interface AuthenticateOptions extends passport.AuthenticateOptions {
   additionalParams?: Record<string, any>;
 }
 
-export interface AuthorizeOptions extends AuthenticateOptions {
-  samlFallback?: "login-request" | "logout-request";
-}
-
 export interface StrategyOptions {
   name?: string;
   passReqToCallback?: boolean;


### PR DESCRIPTION
There was an unused type called `AuthorizeOptions`. Not only was it unused, but it also was redundant, adding no new typing information.